### PR TITLE
feat: playable chess vs ELO-scaled AI opponent (Phase 1 MVP)

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,6 +1,7 @@
 name: Android Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, master, develop ]
     paths:

--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ Contributions are welcome! Please follow these guidelines:
 
 ### Phase 1: MVP (Weeks 1-6)
 - [x] Project setup and architecture
-- [ ] Chess board UI
-- [ ] Stockfish integration
-- [ ] Basic game play
+- [x] Chess board UI
+- [ ] Stockfish integration (interim: built-in RaiEngine, a Kotlin alpha-beta engine with ELO-scaled strength)
+- [x] Basic game play (play vs AI, ELO tracking, resign, auto-queen promotion)
 - [ ] Database setup
 - [ ] Simple analysis
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
 
     // ViewModel
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.2")
 
     // Room Database

--- a/app/src/main/java/com/raichess/MainActivity.kt
+++ b/app/src/main/java/com/raichess/MainActivity.kt
@@ -3,7 +3,6 @@ package com.raichess
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -11,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.raichess.ui.game.GamePhase
 import com.raichess.ui.game.GameScreen
 import com.raichess.ui.game.GameViewModel
@@ -24,9 +24,6 @@ import com.raichess.ui.theme.RaiChessTheme
  * @version 1.0.0-alpha
  */
 class MainActivity : ComponentActivity() {
-
-    private val viewModel: GameViewModel by viewModels()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -35,7 +32,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    RaiChessApp(viewModel)
+                    RaiChessApp()
                 }
             }
         }
@@ -43,7 +40,7 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun RaiChessApp(viewModel: GameViewModel) {
+fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
     val state by viewModel.uiState.collectAsState()
 
     when (state.phase) {

--- a/app/src/main/java/com/raichess/MainActivity.kt
+++ b/app/src/main/java/com/raichess/MainActivity.kt
@@ -3,16 +3,18 @@ package com.raichess
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import com.raichess.ui.game.GamePhase
+import com.raichess.ui.game.GameScreen
+import com.raichess.ui.game.GameViewModel
+import com.raichess.ui.home.HomeScreen
 import com.raichess.ui.theme.RaiChessTheme
 
 /**
@@ -22,6 +24,9 @@ import com.raichess.ui.theme.RaiChessTheme
  * @version 1.0.0-alpha
  */
 class MainActivity : ComponentActivity() {
+
+    private val viewModel: GameViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -30,7 +35,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    WelcomeScreen()
+                    RaiChessApp(viewModel)
                 }
             }
         }
@@ -38,56 +43,24 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun WelcomeScreen() {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .padding(32.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        // App Name in ASCII art style
-        Text(
-            text = "RAICHESS",
-            style = MaterialTheme.typography.displayLarge,
-            color = MaterialTheme.colorScheme.onBackground
+fun RaiChessApp(viewModel: GameViewModel) {
+    val state by viewModel.uiState.collectAsState()
+
+    when (state.phase) {
+        GamePhase.SETUP -> HomeScreen(
+            stats = state.playerStats,
+            opponentElo = state.opponentElo,
+            playerColor = state.playerColor,
+            onOpponentEloChanged = viewModel::setOpponentElo,
+            onPlayerColorChanged = viewModel::setPlayerColor,
+            onStartGame = viewModel::startGame
         )
 
-        Spacer(modifier = Modifier.height(8.dp))
-
-        // Japanese kanji
-        Text(
-            text = "来Chess",
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.onBackground
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Tagline
-        Text(
-            text = "The Next Chess App",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onBackground
-        )
-
-        Spacer(modifier = Modifier.height(48.dp))
-
-        // Status message
-        Text(
-            text = "Development in Progress",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.secondary
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Info about the app
-        Text(
-            text = "Rai (来) = \"Next\" in Japanese\nRighteous!",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onBackground
+        GamePhase.PLAYING, GamePhase.GAME_OVER -> GameScreen(
+            state = state,
+            onSquareTapped = viewModel::onSquareTapped,
+            onResign = viewModel::resign,
+            onNewGame = viewModel::backToSetup
         )
     }
 }

--- a/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
@@ -1,0 +1,193 @@
+package com.raichess.data.engine
+
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.Piece
+import com.github.bhlangonijr.chesslib.PieceType
+import com.github.bhlangonijr.chesslib.Square
+import com.github.bhlangonijr.chesslib.move.Move
+import com.github.bhlangonijr.chesslib.move.MoveGenerator
+import kotlin.math.max
+import kotlin.random.Random
+
+/**
+ * RaiEngine - built-in chess AI for RaiChess.
+ *
+ * A pure-Kotlin alpha-beta engine whose playing strength is scaled to a
+ * target ELO (800-2800). It is the interim opponent until the Stockfish
+ * NDK integration lands; the [selectMove] contract is designed so a
+ * Stockfish-backed implementation can replace it without UI changes.
+ *
+ * Strength scaling:
+ * - Search depth grows with target ELO (1-4 plies)
+ * - Lower ELOs blunder: with some probability a random legal move is played
+ * - Lower ELOs also pick randomly among near-best moves instead of the best
+ */
+class RaiEngine(
+    targetElo: Int,
+    private val random: Random = Random.Default
+) {
+
+    private val elo = targetElo.coerceIn(MIN_ELO, MAX_ELO)
+
+    /** Full-move search depth in plies. */
+    val searchDepth: Int = when {
+        elo < 1000 -> 1
+        elo < 1400 -> 2
+        elo < 2000 -> 3
+        else -> 4
+    }
+
+    /** Probability of playing a completely random legal move. */
+    val blunderChance: Double = when {
+        elo < 1000 -> 0.30
+        elo < 1200 -> 0.20
+        elo < 1400 -> 0.12
+        elo < 1600 -> 0.07
+        elo < 1800 -> 0.04
+        elo < 2000 -> 0.02
+        else -> 0.0
+    }
+
+    /** Moves within this many centipawns of the best are candidates at lower ELOs. */
+    private val candidateWindow: Int = when {
+        elo < 1200 -> 120
+        elo < 1600 -> 60
+        elo < 2000 -> 25
+        else -> 0
+    }
+
+    /**
+     * Select a move for the side to move on [board].
+     * Returns null if the game is over (no legal moves).
+     * The board is left in its original state.
+     */
+    fun selectMove(board: Board): Move? {
+        val legalMoves = MoveGenerator.generateLegalMoves(board)
+        if (legalMoves.isEmpty()) return null
+        if (legalMoves.size == 1) return legalMoves.first()
+
+        if (blunderChance > 0 && random.nextDouble() < blunderChance) {
+            return legalMoves[random.nextInt(legalMoves.size)]
+        }
+
+        val scored = legalMoves
+            .sortedByDescending { captureValue(board, it) }
+            .map { move ->
+                board.doMove(move)
+                val score = -negamax(board, searchDepth - 1, -INFINITY, INFINITY, 1)
+                board.undoMove()
+                move to score
+            }
+
+        val bestScore = scored.maxOf { it.second }
+        val candidates = scored.filter { it.second >= bestScore - candidateWindow }
+        return candidates[random.nextInt(candidates.size)].first
+    }
+
+    private fun negamax(board: Board, depth: Int, alphaIn: Int, beta: Int, ply: Int): Int {
+        if (board.isMated) return -(MATE_SCORE - ply)
+        if (board.isDraw) return 0
+        if (depth <= 0) return evaluate(board)
+
+        var alpha = alphaIn
+        val moves = MoveGenerator.generateLegalMoves(board)
+            .sortedByDescending { captureValue(board, it) }
+
+        var best = -INFINITY
+        for (move in moves) {
+            board.doMove(move)
+            val score = -negamax(board, depth - 1, -beta, -alpha, ply + 1)
+            board.undoMove()
+            best = max(best, score)
+            alpha = max(alpha, score)
+            if (alpha >= beta) break
+        }
+        return best
+    }
+
+    /** Static evaluation in centipawns from the perspective of the side to move. */
+    private fun evaluate(board: Board): Int {
+        var score = 0
+        for (index in 0 until 64) {
+            val square = Square.squareAt(index)
+            val piece = board.getPiece(square)
+            if (piece == Piece.NONE) continue
+
+            val side = piece.pieceSide ?: continue
+            val type = piece.pieceType ?: continue
+            var value = pieceValue(type)
+
+            // Positional bonus from piece-square tables (white perspective tables)
+            val tableIndex = if (side == com.github.bhlangonijr.chesslib.Side.WHITE) {
+                // Tables are listed rank 8 first; square index 0 is a1
+                (7 - index / 8) * 8 + index % 8
+            } else {
+                index
+            }
+            value += when (type) {
+                PieceType.PAWN -> PAWN_TABLE[tableIndex]
+                PieceType.KNIGHT -> KNIGHT_TABLE[tableIndex]
+                PieceType.BISHOP -> BISHOP_TABLE[tableIndex]
+                else -> 0
+            }
+
+            score += if (side == board.sideToMove) value else -value
+        }
+        return score
+    }
+
+    private fun captureValue(board: Board, move: Move): Int {
+        val captured = board.getPiece(move.to)
+        if (captured == Piece.NONE) return 0
+        val type = captured.pieceType ?: return 0
+        return pieceValue(type)
+    }
+
+    private fun pieceValue(type: PieceType): Int = when (type) {
+        PieceType.PAWN -> 100
+        PieceType.KNIGHT -> 320
+        PieceType.BISHOP -> 330
+        PieceType.ROOK -> 500
+        PieceType.QUEEN -> 900
+        else -> 0
+    }
+
+    companion object {
+        const val MIN_ELO = 800
+        const val MAX_ELO = 2800
+        private const val INFINITY = 1_000_000
+        private const val MATE_SCORE = 100_000
+
+        // Piece-square tables (white perspective, rank 8 first)
+        private val PAWN_TABLE = intArrayOf(
+            0, 0, 0, 0, 0, 0, 0, 0,
+            50, 50, 50, 50, 50, 50, 50, 50,
+            10, 10, 20, 30, 30, 20, 10, 10,
+            5, 5, 10, 25, 25, 10, 5, 5,
+            0, 0, 0, 20, 20, 0, 0, 0,
+            5, -5, -10, 0, 0, -10, -5, 5,
+            5, 10, 10, -20, -20, 10, 10, 5,
+            0, 0, 0, 0, 0, 0, 0, 0
+        )
+        private val KNIGHT_TABLE = intArrayOf(
+            -50, -40, -30, -30, -30, -30, -40, -50,
+            -40, -20, 0, 0, 0, 0, -20, -40,
+            -30, 0, 10, 15, 15, 10, 0, -30,
+            -30, 5, 15, 20, 20, 15, 5, -30,
+            -30, 0, 15, 20, 20, 15, 0, -30,
+            -30, 5, 10, 15, 15, 10, 5, -30,
+            -40, -20, 0, 5, 5, 0, -20, -40,
+            -50, -40, -30, -30, -30, -30, -40, -50
+        )
+        private val BISHOP_TABLE = intArrayOf(
+            -20, -10, -10, -10, -10, -10, -10, -20,
+            -10, 0, 0, 0, 0, 0, 0, -10,
+            -10, 0, 5, 10, 10, 5, 0, -10,
+            -10, 5, 5, 10, 10, 5, 5, -10,
+            -10, 0, 10, 10, 10, 10, 0, -10,
+            -10, 10, 10, 10, 10, 10, 10, -10,
+            -10, 5, 0, 0, 0, 0, 5, -10,
+            -20, -10, -10, -10, -10, -10, -10, -20
+        )
+    }
+}

--- a/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
@@ -159,6 +159,8 @@ class RaiEngine(
     }
 
     companion object {
+        // Selectable opponent strength range; intentionally narrower than
+        // EloCalculator's 400-3000, which bounds the player's own rating
         const val MIN_ELO = 800
         const val MAX_ELO = 2800
         private const val INFINITY = 1_000_000

--- a/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
@@ -3,6 +3,7 @@ package com.raichess.data.engine
 import com.github.bhlangonijr.chesslib.Board
 import com.github.bhlangonijr.chesslib.Piece
 import com.github.bhlangonijr.chesslib.PieceType
+import com.github.bhlangonijr.chesslib.Side
 import com.github.bhlangonijr.chesslib.Square
 import com.github.bhlangonijr.chesslib.move.Move
 import com.github.bhlangonijr.chesslib.move.MoveGenerator
@@ -70,12 +71,17 @@ class RaiEngine(
             return legalMoves[random.nextInt(legalMoves.size)]
         }
 
+        // Root alpha is kept candidateWindow below the best score seen, so
+        // pruning never discards a move that could still land in the
+        // near-best candidate set used for weaker-ELO move selection
+        var alpha = -INFINITY
         val scored = legalMoves
             .sortedByDescending { captureValue(board, it) }
             .map { move ->
                 board.doMove(move)
-                val score = -negamax(board, searchDepth - 1, -INFINITY, INFINITY, 1)
+                val score = -negamax(board, searchDepth - 1, -INFINITY, -alpha, 1)
                 board.undoMove()
+                alpha = max(alpha, score - candidateWindow)
                 move to score
             }
 
@@ -118,7 +124,7 @@ class RaiEngine(
             var value = pieceValue(type)
 
             // Positional bonus from piece-square tables (white perspective tables)
-            val tableIndex = if (side == com.github.bhlangonijr.chesslib.Side.WHITE) {
+            val tableIndex = if (side == Side.WHITE) {
                 // Tables are listed rank 8 first; square index 0 is a1
                 (7 - index / 8) * 8 + index % 8
             } else {

--- a/app/src/main/java/com/raichess/data/repository/PlayerProfileRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/PlayerProfileRepository.kt
@@ -1,0 +1,75 @@
+package com.raichess.data.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.raichess.domain.model.EloCalculator
+import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.GameResult
+
+/**
+ * Persists the player's ELO rating and game record.
+ *
+ * SharedPreferences-backed for the MVP; will migrate to Room when the
+ * game-history database (Phase 1 roadmap) is implemented.
+ */
+class PlayerProfileRepository(context: Context) {
+
+    private val prefs: SharedPreferences =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun getStats(): EloStats {
+        val gamesPlayed = prefs.getInt(KEY_GAMES, 0)
+        return EloStats(
+            currentElo = prefs.getInt(KEY_ELO, EloCalculator.DEFAULT_STARTING_ELO),
+            peakElo = prefs.getInt(KEY_PEAK_ELO, EloCalculator.DEFAULT_STARTING_ELO),
+            gamesPlayed = gamesPlayed,
+            wins = prefs.getInt(KEY_WINS, 0),
+            losses = prefs.getInt(KEY_LOSSES, 0),
+            draws = prefs.getInt(KEY_DRAWS, 0),
+            confidenceInterval = EloCalculator.getConfidenceInterval(gamesPlayed)
+        )
+    }
+
+    /**
+     * Record a finished game and return the updated stats plus the ELO delta.
+     *
+     * @param moveAccuracy player's accuracy for the game (50.0 = neutral until
+     *   post-game analysis is implemented)
+     */
+    fun recordResult(
+        result: GameResult,
+        opponentElo: Int,
+        moveAccuracy: Double = 50.0
+    ): Pair<EloStats, Int> {
+        val stats = getStats()
+        val newElo = EloCalculator.calculateNewElo(
+            currentElo = stats.currentElo,
+            opponentElo = opponentElo,
+            result = result,
+            moveAccuracy = moveAccuracy
+        )
+        val delta = newElo - stats.currentElo
+        val updated = stats.withGameResult(newElo, result)
+
+        prefs.edit()
+            .putInt(KEY_ELO, updated.currentElo)
+            .putInt(KEY_PEAK_ELO, updated.peakElo)
+            .putInt(KEY_GAMES, updated.gamesPlayed)
+            .putInt(KEY_WINS, updated.wins)
+            .putInt(KEY_LOSSES, updated.losses)
+            .putInt(KEY_DRAWS, updated.draws)
+            .apply()
+
+        return updated to delta
+    }
+
+    companion object {
+        private const val PREFS_NAME = "raichess_profile"
+        private const val KEY_ELO = "elo"
+        private const val KEY_PEAK_ELO = "peak_elo"
+        private const val KEY_GAMES = "games_played"
+        private const val KEY_WINS = "wins"
+        private const val KEY_LOSSES = "losses"
+        private const val KEY_DRAWS = "draws"
+    }
+}

--- a/app/src/main/java/com/raichess/domain/model/EloCalculator.kt
+++ b/app/src/main/java/com/raichess/domain/model/EloCalculator.kt
@@ -122,6 +122,10 @@ enum class PlayerColor {
 /**
  * ELO configuration for Stockfish
  * Maps target ELO to Stockfish UCI parameters
+ *
+ * Note: these depth/skillLevel/thinkingTime mappings are for the planned
+ * Stockfish UCI integration and are NOT read by the interim RaiEngine,
+ * which derives its own strength scaling from the target ELO.
  */
 data class EloConfiguration(
     val targetElo: Int,

--- a/app/src/main/java/com/raichess/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameScreen.kt
@@ -102,7 +102,7 @@ fun ChessBoard(
     squares: List<Char?>,
     selectedSquare: Int?,
     legalTargets: Set<Int>,
-    lastMove: Pair<Int, Int>?,
+    lastMove: LastMove?,
     flipped: Boolean,
     onSquareTapped: (Int) -> Unit
 ) {
@@ -124,7 +124,7 @@ fun ChessBoard(
                         isLight = (rank + file) % 2 == 1,
                         isSelected = index == selectedSquare,
                         isLegalTarget = index in legalTargets,
-                        isLastMove = lastMove?.let { index == it.first || index == it.second }
+                        isLastMove = lastMove?.let { index == it.from || index == it.to }
                             ?: false,
                         onTap = { onSquareTapped(index) },
                         modifier = Modifier

--- a/app/src/main/java/com/raichess/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameScreen.kt
@@ -1,0 +1,231 @@
+package com.raichess.ui.game
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.raichess.domain.model.PlayerColor
+import com.raichess.ui.theme.ChessColors
+import com.raichess.ui.theme.ChessPieceSymbols
+
+/**
+ * The main game screen: board, status, move list, and controls.
+ */
+@Composable
+fun GameScreen(
+    state: GameUiState,
+    onSquareTapped: (Int) -> Unit,
+    onResign: () -> Unit,
+    onNewGame: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Opponent info
+        Text(
+            text = "RaiEngine · ${state.opponentElo} ELO",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        Text(
+            text = statusText(state),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.padding(vertical = 8.dp)
+        )
+
+        ChessBoard(
+            squares = state.squares,
+            selectedSquare = state.selectedSquare,
+            legalTargets = state.legalTargets,
+            lastMove = state.lastMove,
+            flipped = state.playerColor == PlayerColor.BLACK,
+            onSquareTapped = onSquareTapped
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        MoveHistory(
+            moves = state.moveHistorySan,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            if (state.phase == GamePhase.PLAYING) {
+                OutlinedButton(onClick = onResign) {
+                    Text("Resign")
+                }
+            } else {
+                OutlinedButton(onClick = onNewGame) {
+                    Text("New Game")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ChessBoard(
+    squares: List<Char?>,
+    selectedSquare: Int?,
+    legalTargets: Set<Int>,
+    lastMove: Pair<Int, Int>?,
+    flipped: Boolean,
+    onSquareTapped: (Int) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(1f)
+            .border(2.dp, ChessColors.SquareBorder)
+    ) {
+        // Draw rank 8 at the top for white, rank 1 at the top when flipped
+        val ranks = if (flipped) 0..7 else 7 downTo 0
+        for (rank in ranks) {
+            Row(modifier = Modifier.weight(1f)) {
+                val files = if (flipped) 7 downTo 0 else 0..7
+                for (file in files) {
+                    val index = rank * 8 + file
+                    BoardSquare(
+                        piece = squares.getOrNull(index),
+                        isLight = (rank + file) % 2 == 1,
+                        isSelected = index == selectedSquare,
+                        isLegalTarget = index in legalTargets,
+                        isLastMove = lastMove?.let { index == it.first || index == it.second }
+                            ?: false,
+                        onTap = { onSquareTapped(index) },
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxSize()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoardSquare(
+    piece: Char?,
+    isLight: Boolean,
+    isSelected: Boolean,
+    isLegalTarget: Boolean,
+    isLastMove: Boolean,
+    onTap: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val background = when {
+        isSelected -> ChessColors.SelectedSquare
+        isLight -> ChessColors.LightSquare
+        else -> ChessColors.DarkSquare
+    }
+
+    Box(
+        modifier = modifier
+            .background(background)
+            .border(0.5.dp, ChessColors.SquareBorder)
+            .clickable(onClick = onTap),
+        contentAlignment = Alignment.Center
+    ) {
+        if (isLastMove && !isSelected) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0x55888888))
+            )
+        }
+        if (piece != null) {
+            val isWhitePiece = piece.isUpperCase()
+            Text(
+                text = ChessPieceSymbols.getSymbol(piece),
+                fontSize = 32.sp,
+                textAlign = TextAlign.Center,
+                color = if (isWhitePiece) ChessColors.WhitePiece else ChessColors.BlackPiece,
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    // Shadow keeps pieces visible on same-color squares
+                    shadow = Shadow(
+                        color = if (isWhitePiece) Color.Black else Color.White,
+                        offset = Offset(0f, 0f),
+                        blurRadius = 6f
+                    )
+                )
+            )
+        }
+        if (isLegalTarget) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .background(ChessColors.LegalMoveIndicator, CircleShape)
+            )
+        }
+    }
+}
+
+@Composable
+private fun MoveHistory(moves: List<String>, modifier: Modifier = Modifier) {
+    val movesText = buildString {
+        moves.chunked(2).forEachIndexed { i, pair ->
+            append("${i + 1}. ${pair.joinToString(" ")}  ")
+        }
+    }
+    Text(
+        text = if (movesText.isBlank()) "Moves will appear here" else movesText,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.secondary,
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(vertical = 8.dp)
+    )
+}
+
+private fun statusText(state: GameUiState): String = when {
+    state.ending != null -> when (state.ending) {
+        GameEnding.CHECKMATE_WIN -> "Checkmate — you win!" + eloDeltaText(state)
+        GameEnding.CHECKMATE_LOSS -> "Checkmate — you lose." + eloDeltaText(state)
+        GameEnding.DRAW -> "Draw." + eloDeltaText(state)
+        GameEnding.RESIGNED -> "You resigned." + eloDeltaText(state)
+    }
+    state.isAiThinking -> "RaiEngine is thinking…"
+    state.isPlayerInCheck -> "Check! Your move."
+    state.isPlayerTurn -> "Your move"
+    else -> ""
+}
+
+private fun eloDeltaText(state: GameUiState): String {
+    val delta = state.eloDelta ?: return ""
+    val sign = if (delta >= 0) "+" else ""
+    return " ELO $sign$delta → ${state.playerStats?.currentElo ?: ""}"
+}

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -33,6 +33,9 @@ enum class GamePhase { SETUP, PLAYING, GAME_OVER }
 /** How the game ended, from the player's perspective. */
 enum class GameEnding { CHECKMATE_WIN, CHECKMATE_LOSS, DRAW, RESIGNED }
 
+/** The most recent move, as board indices (a1=0 .. h8=63). */
+data class LastMove(val from: Int, val to: Int)
+
 data class GameUiState(
     val phase: GamePhase = GamePhase.SETUP,
     val playerStats: EloStats? = null,
@@ -42,7 +45,7 @@ data class GameUiState(
     val squares: List<Char?> = emptyList(),
     val selectedSquare: Int? = null,
     val legalTargets: Set<Int> = emptySet(),
-    val lastMove: Pair<Int, Int>? = null,
+    val lastMove: LastMove? = null,
     val moveHistorySan: List<String> = emptyList(),
     val isPlayerTurn: Boolean = false,
     val isAiThinking: Boolean = false,
@@ -195,7 +198,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             squares = boardSnapshot(),
             selectedSquare = null,
             legalTargets = emptySet(),
-            lastMove = move.from.ordinal to move.to.ordinal,
+            lastMove = LastMove(move.from.ordinal, move.to.ordinal),
             moveHistorySan = sanHistory(),
             isPlayerInCheck = isPlayerInCheck()
         )
@@ -267,6 +270,8 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         return board.sideToMove == playerSide && board.isKingAttacked
     }
 
+    // O(moves) per call since toSanArray re-encodes the full list; fine at
+    // one call per ply for normal game lengths, don't reuse in hot paths
     private fun sanHistory(): List<String> = try {
         moveList.toSanArray().toList()
     } catch (e: MoveConversionException) {

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -1,0 +1,283 @@
+package com.raichess.ui.game
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.Piece
+import com.github.bhlangonijr.chesslib.PieceType
+import com.github.bhlangonijr.chesslib.Side
+import com.github.bhlangonijr.chesslib.Square
+import com.github.bhlangonijr.chesslib.move.Move
+import com.github.bhlangonijr.chesslib.move.MoveGenerator
+import com.github.bhlangonijr.chesslib.move.MoveList
+import com.raichess.data.engine.RaiEngine
+import com.raichess.data.repository.PlayerProfileRepository
+import com.raichess.domain.model.EloConfiguration
+import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.GameResult
+import com.raichess.domain.model.PlayerColor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.random.Random
+
+/** Which screen of the game flow is showing. */
+enum class GamePhase { SETUP, PLAYING, GAME_OVER }
+
+/** How the game ended, from the player's perspective. */
+enum class GameEnding { CHECKMATE_WIN, CHECKMATE_LOSS, DRAW, RESIGNED }
+
+data class GameUiState(
+    val phase: GamePhase = GamePhase.SETUP,
+    val playerStats: EloStats? = null,
+    val opponentElo: Int = 1250,
+    val playerColor: PlayerColor = PlayerColor.WHITE,
+    /** FEN piece chars ('P', 'k', ...) or null for empty, indexed a1=0 .. h8=63. */
+    val squares: List<Char?> = emptyList(),
+    val selectedSquare: Int? = null,
+    val legalTargets: Set<Int> = emptySet(),
+    val lastMove: Pair<Int, Int>? = null,
+    val moveHistorySan: List<String> = emptyList(),
+    val isPlayerTurn: Boolean = false,
+    val isAiThinking: Boolean = false,
+    val isPlayerInCheck: Boolean = false,
+    val ending: GameEnding? = null,
+    val eloDelta: Int? = null
+)
+
+class GameViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository = PlayerProfileRepository(application)
+    private val board = Board()
+    private var moveList = MoveList()
+    private var engine: RaiEngine? = null
+    private var gameRecorded = false
+    private var gameId = 0
+
+    private val _uiState = MutableStateFlow(GameUiState(playerStats = repository.getStats()))
+    val uiState: StateFlow<GameUiState> = _uiState.asStateFlow()
+
+    val recommendedOpponentElo: Int
+        get() = EloConfiguration.getRecommendedOpponentElo(
+            repository.getStats().currentElo
+        )
+
+    fun setOpponentElo(elo: Int) {
+        _uiState.value = _uiState.value.copy(
+            opponentElo = elo.coerceIn(RaiEngine.MIN_ELO, RaiEngine.MAX_ELO)
+        )
+    }
+
+    fun setPlayerColor(color: PlayerColor) {
+        _uiState.value = _uiState.value.copy(playerColor = color)
+    }
+
+    fun startGame(randomColor: Boolean = false) {
+        val state = _uiState.value
+        val color = if (randomColor) {
+            if (Random.nextBoolean()) PlayerColor.WHITE else PlayerColor.BLACK
+        } else {
+            state.playerColor
+        }
+
+        board.loadFromFen(START_FEN)
+        moveList = MoveList()
+        engine = RaiEngine(state.opponentElo)
+        gameRecorded = false
+        gameId++
+
+        _uiState.value = state.copy(
+            phase = GamePhase.PLAYING,
+            playerColor = color,
+            squares = boardSnapshot(),
+            selectedSquare = null,
+            legalTargets = emptySet(),
+            lastMove = null,
+            moveHistorySan = emptyList(),
+            isPlayerTurn = color == PlayerColor.WHITE,
+            isAiThinking = false,
+            isPlayerInCheck = false,
+            ending = null,
+            eloDelta = null
+        )
+
+        if (color == PlayerColor.BLACK) {
+            makeAiMove()
+        }
+    }
+
+    fun onSquareTapped(index: Int) {
+        val state = _uiState.value
+        if (state.phase != GamePhase.PLAYING || !state.isPlayerTurn || state.isAiThinking) return
+
+        val selected = state.selectedSquare
+        if (selected != null && index in state.legalTargets) {
+            playPlayerMove(selected, index)
+            return
+        }
+
+        // Select (or re-select) one of the player's own pieces
+        val piece = board.getPiece(Square.squareAt(index))
+        val playerSide = if (state.playerColor == PlayerColor.WHITE) Side.WHITE else Side.BLACK
+        if (piece != Piece.NONE && piece.pieceSide == playerSide) {
+            val targets = legalMovesFrom(index)
+            _uiState.value = state.copy(selectedSquare = index, legalTargets = targets)
+        } else {
+            _uiState.value = state.copy(selectedSquare = null, legalTargets = emptySet())
+        }
+    }
+
+    fun resign() {
+        val state = _uiState.value
+        if (state.phase != GamePhase.PLAYING) return
+        finishGame(GameEnding.RESIGNED, GameResult.LOSS)
+    }
+
+    fun backToSetup() {
+        _uiState.value = _uiState.value.copy(
+            phase = GamePhase.SETUP,
+            playerStats = repository.getStats()
+        )
+    }
+
+    private fun playPlayerMove(fromIndex: Int, toIndex: Int) {
+        val move = findLegalMove(fromIndex, toIndex) ?: return
+        applyMove(move)
+        if (!checkGameOver()) {
+            makeAiMove()
+        }
+    }
+
+    private fun makeAiMove() {
+        val currentEngine = engine ?: return
+        val currentGameId = gameId
+        _uiState.value = _uiState.value.copy(isAiThinking = true, isPlayerTurn = false)
+
+        viewModelScope.launch {
+            val move = withContext(Dispatchers.Default) {
+                currentEngine.selectMove(board)
+            }
+            // Brief pause so instant replies still read as a "thinking" opponent
+            delay(MIN_AI_MOVE_DELAY_MS)
+            // Bail out if the game ended or a new game started while searching
+            if (_uiState.value.phase != GamePhase.PLAYING || gameId != currentGameId) return@launch
+            if (move != null) {
+                applyMove(move)
+            }
+            if (!checkGameOver()) {
+                _uiState.value = _uiState.value.copy(isAiThinking = false, isPlayerTurn = true)
+            }
+        }
+    }
+
+    private fun applyMove(move: Move) {
+        board.doMove(move)
+        moveList.add(move)
+        _uiState.value = _uiState.value.copy(
+            squares = boardSnapshot(),
+            selectedSquare = null,
+            legalTargets = emptySet(),
+            lastMove = move.from.ordinal to move.to.ordinal,
+            moveHistorySan = sanHistory(),
+            isPlayerInCheck = isPlayerInCheck()
+        )
+    }
+
+    /** Returns true when the game ended (and records the result). */
+    private fun checkGameOver(): Boolean {
+        val state = _uiState.value
+        val playerSide = if (state.playerColor == PlayerColor.WHITE) Side.WHITE else Side.BLACK
+        return when {
+            board.isMated -> {
+                // Side to move has been mated
+                if (board.sideToMove == playerSide) {
+                    finishGame(GameEnding.CHECKMATE_LOSS, GameResult.LOSS)
+                } else {
+                    finishGame(GameEnding.CHECKMATE_WIN, GameResult.WIN)
+                }
+                true
+            }
+            board.isDraw -> {
+                finishGame(GameEnding.DRAW, GameResult.DRAW)
+                true
+            }
+            else -> false
+        }
+    }
+
+    private fun finishGame(ending: GameEnding, result: GameResult) {
+        if (gameRecorded) return
+        gameRecorded = true
+        val (stats, delta) = repository.recordResult(result, _uiState.value.opponentElo)
+        _uiState.value = _uiState.value.copy(
+            phase = GamePhase.GAME_OVER,
+            playerStats = stats,
+            isAiThinking = false,
+            isPlayerTurn = false,
+            ending = ending,
+            eloDelta = delta
+        )
+    }
+
+    private fun boardSnapshot(): List<Char?> = (0 until 64).map { index ->
+        val piece = board.getPiece(Square.squareAt(index))
+        if (piece == Piece.NONE) null else piece.fenChar()
+    }
+
+    private fun legalMovesFrom(index: Int): Set<Int> {
+        val from = Square.squareAt(index)
+        return MoveGenerator.generateLegalMoves(board)
+            .filter { it.from == from }
+            .map { it.to.ordinal }
+            .toSet()
+    }
+
+    private fun findLegalMove(fromIndex: Int, toIndex: Int): Move? {
+        val from = Square.squareAt(fromIndex)
+        val to = Square.squareAt(toIndex)
+        val matches = MoveGenerator.generateLegalMoves(board)
+            .filter { it.from == from && it.to == to }
+        if (matches.isEmpty()) return null
+        // Multiple matches means promotion; auto-queen for the MVP
+        return matches.firstOrNull { it.promotion.pieceType == PieceType.QUEEN }
+            ?: matches.first()
+    }
+
+    private fun isPlayerInCheck(): Boolean {
+        val playerSide =
+            if (_uiState.value.playerColor == PlayerColor.WHITE) Side.WHITE else Side.BLACK
+        return board.sideToMove == playerSide && board.isKingAttacked
+    }
+
+    private fun sanHistory(): List<String> = try {
+        moveList.toSanArray().toList()
+    } catch (e: Exception) {
+        // Fall back to coordinate notation if SAN conversion fails
+        moveList.map { it.toString() }
+    }
+
+    private fun Piece.fenChar(): Char? {
+        val type = pieceType ?: return null
+        val char = when (type) {
+            PieceType.PAWN -> 'p'
+            PieceType.KNIGHT -> 'n'
+            PieceType.BISHOP -> 'b'
+            PieceType.ROOK -> 'r'
+            PieceType.QUEEN -> 'q'
+            PieceType.KING -> 'k'
+            else -> return null
+        }
+        return if (pieceSide == Side.WHITE) char.uppercaseChar() else char
+    }
+
+    companion object {
+        private const val START_FEN =
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        private const val MIN_AI_MOVE_DELAY_MS = 350L
+    }
+}

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -9,6 +9,7 @@ import com.github.bhlangonijr.chesslib.PieceType
 import com.github.bhlangonijr.chesslib.Side
 import com.github.bhlangonijr.chesslib.Square
 import com.github.bhlangonijr.chesslib.move.Move
+import com.github.bhlangonijr.chesslib.move.MoveConversionException
 import com.github.bhlangonijr.chesslib.move.MoveGenerator
 import com.github.bhlangonijr.chesslib.move.MoveList
 import com.raichess.data.engine.RaiEngine
@@ -53,7 +54,7 @@ data class GameUiState(
 class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     private val repository = PlayerProfileRepository(application)
-    private val board = Board()
+    private var board = Board()
     private var moveList = MoveList()
     private var engine: RaiEngine? = null
     private var gameRecorded = false
@@ -85,7 +86,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             state.playerColor
         }
 
-        board.loadFromFen(START_FEN)
+        // Fresh Board per game: a stale AI search from a previous game can
+        // never touch the live board even if it is still running
+        board = Board()
         moveList = MoveList()
         engine = RaiEngine(state.opponentElo)
         gameRecorded = false
@@ -156,14 +159,21 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     private fun makeAiMove() {
         val currentEngine = engine ?: return
         val currentGameId = gameId
+        // Snapshot the position so the background search never touches the
+        // live board (resign/new-game can mutate it mid-search otherwise)
+        val positionFen = board.fen
         _uiState.value = _uiState.value.copy(isAiThinking = true, isPlayerTurn = false)
 
         viewModelScope.launch {
+            val startedAt = System.currentTimeMillis()
             val move = withContext(Dispatchers.Default) {
-                currentEngine.selectMove(board)
+                val searchBoard = Board().apply { loadFromFen(positionFen) }
+                currentEngine.selectMove(searchBoard)
             }
-            // Brief pause so instant replies still read as a "thinking" opponent
-            delay(MIN_AI_MOVE_DELAY_MS)
+            // Pause so instant replies still read as a "thinking" opponent,
+            // as a floor on total time rather than an added delay
+            val elapsed = System.currentTimeMillis() - startedAt
+            if (elapsed < MIN_AI_MOVE_DELAY_MS) delay(MIN_AI_MOVE_DELAY_MS - elapsed)
             // Bail out if the game ended or a new game started while searching
             if (_uiState.value.phase != GamePhase.PLAYING || gameId != currentGameId) return@launch
             if (move != null) {
@@ -256,7 +266,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun sanHistory(): List<String> = try {
         moveList.toSanArray().toList()
-    } catch (e: Exception) {
+    } catch (e: MoveConversionException) {
         // Fall back to coordinate notation if SAN conversion fails
         moveList.map { it.toString() }
     }
@@ -276,8 +286,6 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     companion object {
-        private const val START_FEN =
-            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
         private const val MIN_AI_MOVE_DELAY_MS = 350L
     }
 }

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -60,13 +60,16 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     private var gameRecorded = false
     private var gameId = 0
 
-    private val _uiState = MutableStateFlow(GameUiState(playerStats = repository.getStats()))
+    private val _uiState = MutableStateFlow(
+        repository.getStats().let { stats ->
+            GameUiState(
+                playerStats = stats,
+                // Seed the setup screen with the recommended opponent strength
+                opponentElo = EloConfiguration.getRecommendedOpponentElo(stats.currentElo)
+            )
+        }
+    )
     val uiState: StateFlow<GameUiState> = _uiState.asStateFlow()
-
-    val recommendedOpponentElo: Int
-        get() = EloConfiguration.getRecommendedOpponentElo(
-            repository.getStats().currentElo
-        )
 
     fun setOpponentElo(elo: Int) {
         _uiState.value = _uiState.value.copy(

--- a/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.raichess.data.engine.RaiEngine
 import com.raichess.domain.model.EloStats
 import com.raichess.domain.model.PlayerColor
+import kotlin.math.roundToInt
 
 /**
  * Home / new-game setup screen: player rating summary, opponent
@@ -85,7 +86,7 @@ fun HomeScreen(
         )
         Slider(
             value = opponentElo.toFloat(),
-            onValueChange = { onOpponentEloChanged((it / 50).toInt() * 50) },
+            onValueChange = { onOpponentEloChanged((it / 50f).roundToInt() * 50) },
             valueRange = RaiEngine.MIN_ELO.toFloat()..RaiEngine.MAX_ELO.toFloat(),
             colors = SliderDefaults.colors(
                 thumbColor = Color.White,

--- a/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
@@ -1,0 +1,140 @@
+package com.raichess.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.raichess.data.engine.RaiEngine
+import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.PlayerColor
+
+/**
+ * Home / new-game setup screen: player rating summary, opponent
+ * strength selection, color choice, and start button.
+ */
+@Composable
+fun HomeScreen(
+    stats: EloStats?,
+    opponentElo: Int,
+    playerColor: PlayerColor,
+    onOpponentEloChanged: (Int) -> Unit,
+    onPlayerColorChanged: (PlayerColor) -> Unit,
+    onStartGame: (randomColor: Boolean) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "RAICHESS",
+            style = MaterialTheme.typography.displayMedium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        Text(
+            text = "来Chess",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.secondary
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        if (stats != null) {
+            Text(
+                text = "${stats.currentElo}",
+                style = MaterialTheme.typography.displayLarge,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            val confidence =
+                if (stats.confidenceInterval > 0) " ±${stats.confidenceInterval}" else ""
+            Text(
+                text = "Your ELO$confidence",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary
+            )
+            Text(
+                text = "${stats.wins}W · ${stats.draws}D · ${stats.losses}L",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary
+            )
+        }
+
+        Spacer(modifier = Modifier.height(40.dp))
+
+        Text(
+            text = "Opponent: $opponentElo ELO",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        Slider(
+            value = opponentElo.toFloat(),
+            onValueChange = { onOpponentEloChanged((it / 50).toInt() * 50) },
+            valueRange = RaiEngine.MIN_ELO.toFloat()..RaiEngine.MAX_ELO.toFloat(),
+            colors = SliderDefaults.colors(
+                thumbColor = Color.White,
+                activeTrackColor = Color.White,
+                inactiveTrackColor = Color(0xFF333333)
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Play as",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            ColorChoiceButton("White ♔", playerColor == PlayerColor.WHITE) {
+                onPlayerColorChanged(PlayerColor.WHITE)
+            }
+            ColorChoiceButton("Black ♚", playerColor == PlayerColor.BLACK) {
+                onPlayerColorChanged(PlayerColor.BLACK)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(40.dp))
+
+        Button(
+            onClick = { onStartGame(false) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Start Game")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedButton(
+            onClick = { onStartGame(true) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Random Color")
+        }
+    }
+}
+
+@Composable
+private fun ColorChoiceButton(label: String, selected: Boolean, onClick: () -> Unit) {
+    if (selected) {
+        Button(onClick = onClick) { Text(label) }
+    } else {
+        OutlinedButton(onClick = onClick) { Text(label) }
+    }
+}

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- RaiChess launcher foreground: white 2x2 checkerboard on transparent,
+     kept inside the adaptive-icon safe zone (66/108 centered) -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M30,30 h24 v24 h-24 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M54,54 h24 v24 h-24 z" />
+    <path
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="3"
+        android:fillColor="#00000000"
+        android:pathData="M30,30 h48 v48 h-48 z" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@android:color/black" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@android:color/black" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap/ic_launcher.xml
+++ b/app/src/main/res/mipmap/ic_launcher.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Fallback launcher icon for API 24-25 (pre-adaptive-icon):
+     black tile with a white 2x2 checkerboard -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M0,0 h108 v108 h-108 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M30,30 h24 v24 h-24 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M54,54 h24 v24 h-24 z" />
+    <path
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="3"
+        android:fillColor="#00000000"
+        android:pathData="M30,30 h48 v48 h-48 z" />
+</vector>

--- a/app/src/main/res/mipmap/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap/ic_launcher_round.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Fallback launcher icon for API 24-25 (pre-adaptive-icon):
+     black tile with a white 2x2 checkerboard -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M0,0 h108 v108 h-108 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M30,30 h24 v24 h-24 z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M54,54 h24 v24 h-24 z" />
+    <path
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="3"
+        android:fillColor="#00000000"
+        android:pathData="M30,30 h48 v48 h-48 z" />
+</vector>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Backup rules for Android 11 and below (fullBackupContent) -->
+<full-backup-content>
+    <!-- Back up the player profile (ELO rating and game record) -->
+    <include domain="sharedpref" path="raichess_profile.xml" />
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Backup rules for Android 12+ (dataExtractionRules) -->
+<data-extraction-rules>
+    <cloud-backup>
+        <!-- Back up the player profile (ELO rating and game record) -->
+        <include domain="sharedpref" path="raichess_profile.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="sharedpref" path="raichess_profile.xml" />
+    </device-transfer>
+</data-extraction-rules>

--- a/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
@@ -80,6 +80,25 @@ class RaiEngineTest {
     }
 
     @Test
+    fun `weak engine deviates from the best move on some seeds`() {
+        // Hanging queen: the objectively best move is c4xd5. An 800-ELO
+        // engine blunders 30% of the time, so across many seeds it must
+        // sometimes play something else.
+        var deviated = false
+        for (seed in 0..40) {
+            val board = Board()
+            board.loadFromFen("rnb1kbnr/ppp1pppp/8/3q4/2P5/8/PP1PPPPP/RNBQKBNR w KQkq - 0 3")
+            val engine = RaiEngine(targetElo = 800, random = Random(seed))
+            val move = checkNotNull(engine.selectMove(board))
+            if (move.toString() != "c4d5") {
+                deviated = true
+                break
+            }
+        }
+        assertTrue("an 800-ELO engine should not always find the best move", deviated)
+    }
+
+    @Test
     fun `weak engine still plays legal moves`() {
         val board = Board()
         val engine = RaiEngine(targetElo = 800, random = Random(99))

--- a/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
@@ -37,6 +37,16 @@ class RaiEngineTest {
     }
 
     @Test
+    fun `stalemate is a draw with no legal moves`() {
+        val board = Board()
+        // Classic queen stalemate: black to move, not in check, no legal moves
+        board.loadFromFen("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1")
+        assertTrue("stalemate should register as a draw", board.isDraw)
+        assertTrue("stalemate is not checkmate", !board.isMated)
+        assertNull(RaiEngine(targetElo = 1500).selectMove(board))
+    }
+
+    @Test
     fun `strong engine finds mate in one`() {
         val board = Board()
         // Back-rank mate available: Ra8#

--- a/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
@@ -99,6 +99,22 @@ class RaiEngineTest {
     }
 
     @Test
+    fun `weak engine varies its opening move across seeds`() {
+        // At low ELO the candidate window keeps several similarly-scored
+        // moves alive, so different seeds should produce different moves
+        val chosen = mutableSetOf<String>()
+        for (seed in 0..20) {
+            val board = Board()
+            val engine = RaiEngine(targetElo = 900, random = Random(seed))
+            chosen.add(checkNotNull(engine.selectMove(board)).toString())
+        }
+        assertTrue(
+            "a weak engine should not play deterministically, got $chosen",
+            chosen.size > 1
+        )
+    }
+
+    @Test
     fun `weak engine still plays legal moves`() {
         val board = Board()
         val engine = RaiEngine(targetElo = 800, random = Random(99))

--- a/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
@@ -1,0 +1,83 @@
+package com.raichess.data.engine
+
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.move.MoveGenerator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class RaiEngineTest {
+
+    @Test
+    fun `returns a legal move from the starting position`() {
+        val board = Board()
+        val engine = RaiEngine(targetElo = 1200, random = Random(42))
+        val move = engine.selectMove(board)
+
+        val legalMoves = MoveGenerator.generateLegalMoves(board)
+        assertTrue("move $move should be legal", legalMoves.contains(move))
+    }
+
+    @Test
+    fun `board is unchanged after move selection`() {
+        val board = Board()
+        val fenBefore = board.fen
+        RaiEngine(targetElo = 2000, random = Random(7)).selectMove(board)
+        assertEquals(fenBefore, board.fen)
+    }
+
+    @Test
+    fun `returns null when the game is over`() {
+        val board = Board()
+        // Fool's mate: white is checkmated
+        board.loadFromFen("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 1 3")
+        assertNull(RaiEngine(targetElo = 1500).selectMove(board))
+    }
+
+    @Test
+    fun `strong engine finds mate in one`() {
+        val board = Board()
+        // Back-rank mate available: Ra8#
+        board.loadFromFen("6k1/5ppp/8/8/8/8/5PPP/R5K1 w - - 0 1")
+        val engine = RaiEngine(targetElo = 2800, random = Random(1))
+        val move = checkNotNull(engine.selectMove(board))
+
+        board.doMove(move)
+        assertTrue("expected a mating move, got $move", board.isMated)
+    }
+
+    @Test
+    fun `strong engine captures a hanging queen`() {
+        val board = Board()
+        // Black queen on d5 can be captured by the c4 pawn
+        board.loadFromFen("rnb1kbnr/ppp1pppp/8/3q4/2P5/8/PP1PPPPP/RNBQKBNR w KQkq - 0 3")
+        val engine = RaiEngine(targetElo = 2400, random = Random(3))
+        val move = checkNotNull(engine.selectMove(board))
+        assertEquals("c4d5", move.toString())
+    }
+
+    @Test
+    fun `search depth scales with target elo`() {
+        assertTrue(RaiEngine(900).searchDepth < RaiEngine(2500).searchDepth)
+    }
+
+    @Test
+    fun `blunder chance decreases with target elo`() {
+        assertTrue(RaiEngine(900).blunderChance > RaiEngine(1800).blunderChance)
+        assertEquals(0.0, RaiEngine(2400).blunderChance, 0.0001)
+    }
+
+    @Test
+    fun `weak engine still plays legal moves`() {
+        val board = Board()
+        val engine = RaiEngine(targetElo = 800, random = Random(99))
+        repeat(10) {
+            val move = engine.selectMove(board) ?: return
+            val legalMoves = MoveGenerator.generateLegalMoves(board)
+            assertTrue("move $move should be legal", legalMoves.contains(move))
+            board.doMove(move)
+        }
+    }
+}

--- a/app/src/test/java/com/raichess/domain/model/EloCalculatorTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/EloCalculatorTest.kt
@@ -1,0 +1,105 @@
+package com.raichess.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EloCalculatorTest {
+
+    @Test
+    fun `expected score is half for equal ratings`() {
+        assertEquals(0.5, EloCalculator.calculateExpectedScore(1500, 1500), 0.001)
+    }
+
+    @Test
+    fun `expected scores of both players sum to one`() {
+        val a = EloCalculator.calculateExpectedScore(1400, 1700)
+        val b = EloCalculator.calculateExpectedScore(1700, 1400)
+        assertEquals(1.0, a + b, 0.001)
+    }
+
+    @Test
+    fun `win against equal opponent increases rating`() {
+        val newElo = EloCalculator.calculateNewElo(1200, 1200, GameResult.WIN, 50.0)
+        assertTrue("expected rating gain, got $newElo", newElo > 1200)
+    }
+
+    @Test
+    fun `loss against equal opponent decreases rating`() {
+        val newElo = EloCalculator.calculateNewElo(1200, 1200, GameResult.LOSS, 50.0)
+        assertTrue("expected rating loss, got $newElo", newElo < 1200)
+    }
+
+    @Test
+    fun `high accuracy softens a loss`() {
+        val sloppyLoss = EloCalculator.calculateNewElo(1200, 1200, GameResult.LOSS, 30.0)
+        val accurateLoss = EloCalculator.calculateNewElo(1200, 1200, GameResult.LOSS, 90.0)
+        assertTrue(accurateLoss > sloppyLoss)
+    }
+
+    @Test
+    fun `rating never drops below minimum`() {
+        val newElo = EloCalculator.calculateNewElo(
+            EloCalculator.MIN_ELO, 2800, GameResult.LOSS, 0.0
+        )
+        assertTrue(newElo >= EloCalculator.MIN_ELO)
+    }
+
+    @Test
+    fun `rating never exceeds maximum`() {
+        val newElo = EloCalculator.calculateNewElo(
+            EloCalculator.MAX_ELO, 800, GameResult.WIN, 100.0
+        )
+        assertTrue(newElo <= EloCalculator.MAX_ELO)
+    }
+
+    @Test
+    fun `confidence interval shrinks with games played`() {
+        assertTrue(
+            EloCalculator.getConfidenceInterval(0) >
+                EloCalculator.getConfidenceInterval(10)
+        )
+        assertEquals(0, EloCalculator.getConfidenceInterval(100))
+    }
+
+    @Test
+    fun `pgn result maps to player perspective`() {
+        assertEquals(GameResult.WIN, GameResult.fromPgnResult("1-0", PlayerColor.WHITE))
+        assertEquals(GameResult.LOSS, GameResult.fromPgnResult("1-0", PlayerColor.BLACK))
+        assertEquals(GameResult.WIN, GameResult.fromPgnResult("0-1", PlayerColor.BLACK))
+        assertEquals(GameResult.DRAW, GameResult.fromPgnResult("1/2-1/2", PlayerColor.WHITE))
+    }
+
+    @Test
+    fun `elo configuration depth increases with target elo`() {
+        val low = EloConfiguration.forElo(900)
+        val mid = EloConfiguration.forElo(1700)
+        val high = EloConfiguration.forElo(2700)
+        assertTrue(low.depth < mid.depth)
+        assertTrue(mid.depth < high.depth)
+    }
+
+    @Test
+    fun `recommended opponent is slightly above player`() {
+        assertEquals(1250, EloConfiguration.getRecommendedOpponentElo(1200))
+        assertEquals(2800, EloConfiguration.getRecommendedOpponentElo(2900))
+    }
+
+    @Test
+    fun `stats update tracks record and peak`() {
+        val stats = EloStats(
+            currentElo = 1200, peakElo = 1200, gamesPlayed = 0,
+            wins = 0, losses = 0, draws = 0, confidenceInterval = 150
+        )
+        val afterWin = stats.withGameResult(1216, GameResult.WIN)
+        assertEquals(1216, afterWin.currentElo)
+        assertEquals(1216, afterWin.peakElo)
+        assertEquals(1, afterWin.wins)
+        assertEquals(1, afterWin.gamesPlayed)
+
+        val afterLoss = afterWin.withGameResult(1200, GameResult.LOSS)
+        assertEquals(1200, afterLoss.currentElo)
+        assertEquals(1216, afterLoss.peakElo)
+        assertEquals(1, afterLoss.losses)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // chesslib is published via JitPack only
+        maven(url = "https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
Implements the core gameplay milestone from the roadmap:

- RaiEngine: pure-Kotlin alpha-beta engine on chesslib with strength
  scaled to a target ELO (800-2800) via search depth, blunder chance,
  and near-best move selection; interim opponent until the Stockfish
  NDK integration lands
- Game screen: tap-to-move Compose board with legal-move indicators,
  last-move highlight, SAN move history, check/mate/draw status,
  resign, and auto-queen promotion
- Home screen: player ELO with confidence interval and W/D/L record,
  opponent strength slider, color selection
- PlayerProfileRepository: SharedPreferences-backed ELO persistence
  using the existing EloCalculator (Room migration planned)
- Unit tests for EloCalculator and RaiEngine (legality, mate-in-one,
  capture preference, strength scaling)
- settings.gradle.kts: add JitPack repository - chesslib is published
  only there, so dependency resolution was previously broken
- CI: allow manual runs via workflow_dispatch

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X5xeW7g9W8cm4Z3h1QYa3T