### PR TITLE
feat: Phase A of coaching roadmap — game storage, engine analyze(), post-game analysis

### DIFF
--- a/TECHNICAL_PLAN.md
+++ b/TECHNICAL_PLAN.md
@@ -405,7 +405,10 @@ class EloCalculator {
 
 3. **Calculate overall metrics:**
    - Average centipawn loss (ACPL)
-   - Accuracy percentage: `max(0, 100 - ACPL)`
+   - Accuracy percentage: `max(0, 100 - ACPL * 0.25)` (ACPL in centipawns;
+     implemented in `MoveClassifier.accuracyFromAcpl` — deliberately gentler
+     than the earlier `100 - ACPL` draft, which floored to 0% at 1 pawn of
+     average loss)
    - Move quality distribution
 
 4. **Identify critical moments:**
@@ -413,10 +416,10 @@ class EloCalculator {
    - Missed tactical opportunities
    - Time pressure mistakes (if timed)
 
-**Example Accuracy Calculation:**
+**Accuracy Calculation (as implemented in `MoveClassifier`):**
 ```kotlin
-fun calculateAccuracy(centipawnLoss: Double): Double {
-    return max(0.0, 100.0 - (centipawnLoss * 2.5))
+fun accuracyFromAcpl(acplCp: Double): Double {
+    return max(0.0, 100.0 - acplCp * 0.25)
 }
 ```
 

--- a/app/src/main/java/com/raichess/MainActivity.kt
+++ b/app/src/main/java/com/raichess/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.raichess.data.analysis.AnalysisCoordinator
 import com.raichess.ui.game.GamePhase
 import com.raichess.ui.game.GameScreen
 import com.raichess.ui.game.GameViewModel
@@ -26,6 +27,9 @@ import com.raichess.ui.theme.RaiChessTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Finish any post-game analysis a previous process didn't complete
+        // (fire-and-forget; no-op when nothing is pending)
+        AnalysisCoordinator.analyzePendingGames(applicationContext)
         setContent {
             RaiChessTheme {
                 Surface(

--- a/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
+++ b/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Owns the background post-game analysis work. Runs on an app-lifetime
@@ -31,8 +32,14 @@ object AnalysisCoordinator {
 
     private const val TAG = "AnalysisCoordinator"
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    // IO, not Default: analysis time is dominated by blocking waits on the
+    // engine's output queue, and Default's small pool is what the live
+    // game's own move search runs on — analysis must not starve it.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val engineMutex = Mutex()
+    // The PENDING backlog only needs draining once per process; later games
+    // are analyzed by their own saveAndAnalyze call.
+    private val sweepRequested = AtomicBoolean(false)
 
     /**
      * Persist a finished game and analyze it in the background. Fire and
@@ -48,7 +55,7 @@ object AnalysisCoordinator {
             } catch (e: Exception) {
                 // Never let a persistence hiccup surface at game over; the
                 // ELO update has its own (SharedPreferences) path.
-                Log.w(TAG, "failed to save finished game", e)
+                Log.w(TAG, "failed to save or analyze finished game", e)
             }
         }
     }
@@ -60,6 +67,9 @@ object AnalysisCoordinator {
      * N init/teardown cycles.
      */
     fun analyzePendingGames(context: Context) {
+        // MainActivity calls this from onCreate, which re-runs on every
+        // activity re-creation (rotation, theme change) — sweep only once
+        if (!sweepRequested.compareAndSet(false, true)) return
         val appContext = context.applicationContext
         scope.launch {
             val repository = GameRepository(appContext)

--- a/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
+++ b/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
@@ -2,6 +2,8 @@ package com.raichess.data.analysis
 
 import android.content.Context
 import android.util.Log
+import com.raichess.data.database.AnalysisState
+import com.raichess.data.engine.ChessEngine
 import com.raichess.data.engine.EngineFactory
 import com.raichess.data.repository.GameRepository
 import com.raichess.domain.model.CompletedGame
@@ -51,14 +53,22 @@ object AnalysisCoordinator {
         }
     }
 
-    /** Drain games whose analysis never completed (app killed mid-run, ...). */
+    /**
+     * Drain games whose analysis never completed (app killed mid-run, ...).
+     * The whole backlog shares one engine instance — a WebView-backed
+     * Stockfish is expensive to spin up, so a sweep of N games must not pay
+     * N init/teardown cycles.
+     */
     fun analyzePendingGames(context: Context) {
         val appContext = context.applicationContext
         scope.launch {
             val repository = GameRepository(appContext)
             try {
-                repository.pendingAnalysisGameIds()
-                    .forEach { analyzeGame(appContext, repository, it) }
+                val pending = repository.pendingAnalysisGameIds()
+                if (pending.isEmpty()) return@launch
+                withAnalysisEngine(appContext) { engine ->
+                    pending.forEach { analyzeGameWith(engine, repository, it) }
+                }
             } catch (e: Exception) {
                 Log.w(TAG, "pending-analysis sweep failed", e)
             }
@@ -70,29 +80,57 @@ object AnalysisCoordinator {
         repository: GameRepository,
         gameId: Long
     ) {
-        engineMutex.withLock {
-            val game = repository.getGame(gameId) ?: return
-            val movesLan = game.movesLan.split(' ').filter { it.isNotBlank() }
-            val playerIsWhite = game.playerColor == PlayerColor.WHITE.name
+        withAnalysisEngine(appContext) { engine ->
+            analyzeGameWith(engine, repository, gameId)
+        }
+    }
 
+    /**
+     * Run [block] with a fresh full-strength engine under [engineMutex]
+     * (ChessEngine is single-caller, and one engine at a time is also the
+     * right battery/memory behaviour), releasing the engine afterwards.
+     */
+    private suspend fun withAnalysisEngine(
+        appContext: Context,
+        block: suspend (ChessEngine) -> Unit
+    ) {
+        engineMutex.withLock {
             val engine = EngineFactory.createAnalyzer(appContext)
             try {
-                val report = GameAnalyzer(engine).analyze(movesLan, playerIsWhite)
-                if (report != null) {
-                    repository.recordAnalysis(gameId, report)
-                    Log.i(TAG, "analyzed game $gameId: accuracy=${"%.1f".format(report.accuracy)}")
-                } else {
-                    repository.markAnalysisFailed(gameId)
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "analysis failed for game $gameId", e)
-                try {
-                    repository.markAnalysisFailed(gameId)
-                } catch (persist: Exception) {
-                    Log.w(TAG, "could not mark game $gameId failed", persist)
-                }
+                block(engine)
             } finally {
                 engine.close()
+            }
+        }
+    }
+
+    /** Analyze one stored game. Caller supplies the engine and holds [engineMutex]. */
+    private suspend fun analyzeGameWith(
+        engine: ChessEngine,
+        repository: GameRepository,
+        gameId: Long
+    ) {
+        val game = repository.getGame(gameId) ?: return
+        // Re-check state: a game saved and analyzed by saveAndAnalyze while a
+        // sweep was waiting on the mutex must not be analyzed twice.
+        if (game.analysisState != AnalysisState.PENDING) return
+        val movesLan = game.movesLan.split(' ').filter { it.isNotBlank() }
+        val playerIsWhite = game.playerColor == PlayerColor.WHITE.name
+
+        try {
+            val report = GameAnalyzer(engine).analyze(movesLan, playerIsWhite)
+            if (report != null) {
+                repository.recordAnalysis(gameId, report)
+                Log.i(TAG, "analyzed game $gameId: accuracy=${"%.1f".format(report.accuracy)}")
+            } else {
+                repository.markAnalysisFailed(gameId)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "analysis failed for game $gameId", e)
+            try {
+                repository.markAnalysisFailed(gameId)
+            } catch (persist: Exception) {
+                Log.w(TAG, "could not mark game $gameId failed", persist)
             }
         }
     }

--- a/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
+++ b/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
@@ -1,0 +1,99 @@
+package com.raichess.data.analysis
+
+import android.content.Context
+import android.util.Log
+import com.raichess.data.engine.EngineFactory
+import com.raichess.data.repository.GameRepository
+import com.raichess.domain.model.CompletedGame
+import com.raichess.domain.model.PlayerColor
+import com.raichess.domain.usecase.GameAnalyzer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Owns the background post-game analysis work. Runs on an app-lifetime
+ * scope, not a ViewModel scope, so leaving the game screen doesn't cancel
+ * an in-flight analysis; if the process dies mid-run anyway, the game's
+ * PENDING state survives and [analyzePendingGames] finishes the job on the
+ * next launch.
+ *
+ * Analyses are serialized by [engineMutex]: ChessEngine is single-caller,
+ * and one full-strength engine at a time is also the right battery/memory
+ * behaviour on a phone.
+ */
+object AnalysisCoordinator {
+
+    private const val TAG = "AnalysisCoordinator"
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val engineMutex = Mutex()
+
+    /**
+     * Persist a finished game and analyze it in the background. Fire and
+     * forget — safe to call from the UI at game over.
+     */
+    fun saveAndAnalyze(context: Context, game: CompletedGame) {
+        val appContext = context.applicationContext
+        scope.launch {
+            val repository = GameRepository(appContext)
+            try {
+                val gameId = repository.saveCompletedGame(game)
+                analyzeGame(appContext, repository, gameId)
+            } catch (e: Exception) {
+                // Never let a persistence hiccup surface at game over; the
+                // ELO update has its own (SharedPreferences) path.
+                Log.w(TAG, "failed to save finished game", e)
+            }
+        }
+    }
+
+    /** Drain games whose analysis never completed (app killed mid-run, ...). */
+    fun analyzePendingGames(context: Context) {
+        val appContext = context.applicationContext
+        scope.launch {
+            val repository = GameRepository(appContext)
+            try {
+                repository.pendingAnalysisGameIds()
+                    .forEach { analyzeGame(appContext, repository, it) }
+            } catch (e: Exception) {
+                Log.w(TAG, "pending-analysis sweep failed", e)
+            }
+        }
+    }
+
+    private suspend fun analyzeGame(
+        appContext: Context,
+        repository: GameRepository,
+        gameId: Long
+    ) {
+        engineMutex.withLock {
+            val game = repository.getGame(gameId) ?: return
+            val movesLan = game.movesLan.split(' ').filter { it.isNotBlank() }
+            val playerIsWhite = game.playerColor == PlayerColor.WHITE.name
+
+            val engine = EngineFactory.createAnalyzer(appContext)
+            try {
+                val report = GameAnalyzer(engine).analyze(movesLan, playerIsWhite)
+                if (report != null) {
+                    repository.recordAnalysis(gameId, report)
+                    Log.i(TAG, "analyzed game $gameId: accuracy=${"%.1f".format(report.accuracy)}")
+                } else {
+                    repository.markAnalysisFailed(gameId)
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "analysis failed for game $gameId", e)
+                try {
+                    repository.markAnalysisFailed(gameId)
+                } catch (persist: Exception) {
+                    Log.w(TAG, "could not mark game $gameId failed", persist)
+                }
+            } finally {
+                engine.close()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/raichess/data/database/Entities.kt
+++ b/app/src/main/java/com/raichess/data/database/Entities.kt
@@ -1,0 +1,144 @@
+package com.raichess.data.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import com.raichess.domain.model.PracticeCategory
+import com.raichess.domain.model.PracticePosition
+
+/**
+ * A finished game. The PGN is the canonical record; [movesLan] duplicates
+ * the moves in raw LAN so analysis (and future re-analysis at higher depth)
+ * can replay the game without a PGN parser.
+ *
+ * The row is written immediately at game over with [analysisState] PENDING;
+ * the background analysis pass later fills [accuracy] and flips the state.
+ * PENDING rows surviving an app restart are picked up by the next analysis
+ * sweep — nothing is lost if analysis is interrupted.
+ */
+@Entity(tableName = "games")
+data class GameEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val pgn: String,
+    /** Space-separated lowercase LAN plies, in play order. */
+    val movesLan: String,
+    val datePlayed: Long,
+    /** PGN result tag: "1-0", "0-1", "1/2-1/2". */
+    val result: String,
+    /** [com.raichess.domain.model.PlayerColor] name. */
+    val playerColor: String,
+    val opponentElo: Int,
+    val playerEloBefore: Int,
+    val playerEloAfter: Int,
+    /** [com.raichess.domain.model.GameMode] name. */
+    val gameMode: String,
+    /** Training-mode undos used in this game. */
+    val undoCount: Int,
+    /** Player accuracy 0–100 from post-game analysis, null until analyzed. */
+    val accuracy: Double?,
+    /** One of [AnalysisState]'s constants. */
+    val analysisState: String,
+    /** Reserved for the opening-recognition phase. */
+    val openingName: String? = null,
+    val createdAt: Long
+)
+
+/** Values for [GameEntity.analysisState]. */
+object AnalysisState {
+    const val PENDING = "PENDING"
+    const val DONE = "DONE"
+    const val FAILED = "FAILED"
+}
+
+/**
+ * One analyzed ply of a stored game: the position as it stood before the
+ * move, the engine's verdict, and — for the player's own moves — how much
+ * the move cost. These rows are the immutable observations that the
+ * weakness profile and practice selection are derived from; interpretation
+ * (themes, profiles) can always be recomputed from them.
+ */
+@Entity(
+    tableName = "positions",
+    foreignKeys = [
+        ForeignKey(
+            entity = GameEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["gameId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("gameId")]
+)
+data class PositionEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val gameId: Long,
+    /** 0-based ply index; White played the even plies. */
+    val ply: Int,
+    /** FEN before the move was played. */
+    val fen: String,
+    /** Eval of [fen] in centipawns from White's perspective, mate-capped. */
+    val evaluationCp: Int,
+    /** Engine's best move in LAN, null for terminal positions. */
+    val bestMove: String?,
+    /** The move actually played, LAN. */
+    val movePlayed: String,
+    val isPlayerMove: Boolean,
+    /** Centipawns the move threw away; null for the AI's moves. */
+    val centipawnLoss: Int?,
+    /** [com.raichess.domain.model.MoveClassification] name; null for AI moves. */
+    val classification: String?,
+    /** Comma-separated theme tags (hanging_piece, missed_fork, ...); filled by the tagging phase. */
+    val themes: String = "",
+    /** Search depth the verdict came from. */
+    val analysisDepth: Int,
+    /** Version of the analysis pipeline that wrote this row, for re-analysis. */
+    val analyzerVersion: Int
+)
+
+/**
+ * Room row for a practice position — field-for-field the domain
+ * [PracticePosition], which SharedPreferences previously persisted as JSON
+ * (see PracticeRepository's legacy import).
+ */
+@Entity(tableName = "practice_positions")
+data class PracticePositionEntity(
+    @PrimaryKey val id: String,
+    val sourceGameId: Long?,
+    val sourceMoveNumber: Int,
+    val fen: String,
+    /** [PracticeCategory] name. */
+    val category: String,
+    val difficulty: Int,
+    val timesPracticed: Int,
+    val successRate: Double,
+    val lastPracticed: Long?,
+    val createdAt: Long
+)
+
+fun PracticePositionEntity.toDomain() = PracticePosition(
+    id = id,
+    sourceGameId = sourceGameId,
+    sourceMoveNumber = sourceMoveNumber,
+    fen = fen,
+    category = runCatching { PracticeCategory.valueOf(category) }
+        .getOrDefault(PracticeCategory.MISTAKE_CORRECTION),
+    difficulty = difficulty,
+    timesPracticed = timesPracticed,
+    successRate = successRate,
+    lastPracticed = lastPracticed,
+    createdAt = createdAt
+)
+
+fun PracticePosition.toEntity() = PracticePositionEntity(
+    id = id,
+    sourceGameId = sourceGameId,
+    sourceMoveNumber = sourceMoveNumber,
+    fen = fen,
+    category = category.name,
+    difficulty = difficulty,
+    timesPracticed = timesPracticed,
+    successRate = successRate,
+    lastPracticed = lastPracticed,
+    createdAt = createdAt
+)

--- a/app/src/main/java/com/raichess/data/database/GameDao.kt
+++ b/app/src/main/java/com/raichess/data/database/GameDao.kt
@@ -1,0 +1,43 @@
+package com.raichess.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+interface GameDao {
+
+    @Insert
+    suspend fun insertGame(game: GameEntity): Long
+
+    @Insert
+    suspend fun insertPositions(positions: List<PositionEntity>)
+
+    @Query("SELECT * FROM games WHERE id = :gameId")
+    suspend fun getGame(gameId: Long): GameEntity?
+
+    @Query("SELECT * FROM games ORDER BY datePlayed DESC LIMIT :limit")
+    suspend fun recentGames(limit: Int): List<GameEntity>
+
+    @Query("SELECT * FROM positions WHERE gameId = :gameId ORDER BY ply")
+    suspend fun positionsForGame(gameId: Long): List<PositionEntity>
+
+    /** Oldest-first so an interrupted backlog drains in play order. */
+    @Query("SELECT id FROM games WHERE analysisState = 'PENDING' ORDER BY datePlayed ASC")
+    suspend fun pendingAnalysisGameIds(): List<Long>
+
+    @Query("UPDATE games SET accuracy = :accuracy, analysisState = :state WHERE id = :gameId")
+    suspend fun setAnalysisResult(gameId: Long, accuracy: Double?, state: String)
+
+    /** Clear any half-written rows from a previous attempt, then store the new ones. */
+    @Query("DELETE FROM positions WHERE gameId = :gameId")
+    suspend fun deletePositionsForGame(gameId: Long)
+
+    @Transaction
+    suspend fun recordAnalysis(gameId: Long, positions: List<PositionEntity>, accuracy: Double?) {
+        deletePositionsForGame(gameId)
+        insertPositions(positions)
+        setAnalysisResult(gameId, accuracy, AnalysisState.DONE)
+    }
+}

--- a/app/src/main/java/com/raichess/data/database/GameDao.kt
+++ b/app/src/main/java/com/raichess/data/database/GameDao.kt
@@ -25,10 +25,11 @@ interface GameDao {
 
     /**
      * Oldest-first so an interrupted backlog drains in play order. The
-     * 'PENDING' literal must stay in sync with [AnalysisState.PENDING] —
-     * Room queries are raw SQL, so the constant can't be referenced here.
+     * state is interpolated from [AnalysisState.PENDING] — legal in a
+     * Room query because const val interpolation is a compile-time
+     * constant — so a rename can't silently desync the SQL.
      */
-    @Query("SELECT id FROM games WHERE analysisState = 'PENDING' ORDER BY datePlayed ASC")
+    @Query("SELECT id FROM games WHERE analysisState = '${AnalysisState.PENDING}' ORDER BY datePlayed ASC")
     suspend fun pendingAnalysisGameIds(): List<Long>
 
     @Query("UPDATE games SET accuracy = :accuracy, analysisState = :state WHERE id = :gameId")

--- a/app/src/main/java/com/raichess/data/database/GameDao.kt
+++ b/app/src/main/java/com/raichess/data/database/GameDao.kt
@@ -23,7 +23,11 @@ interface GameDao {
     @Query("SELECT * FROM positions WHERE gameId = :gameId ORDER BY ply")
     suspend fun positionsForGame(gameId: Long): List<PositionEntity>
 
-    /** Oldest-first so an interrupted backlog drains in play order. */
+    /**
+     * Oldest-first so an interrupted backlog drains in play order. The
+     * 'PENDING' literal must stay in sync with [AnalysisState.PENDING] —
+     * Room queries are raw SQL, so the constant can't be referenced here.
+     */
     @Query("SELECT id FROM games WHERE analysisState = 'PENDING' ORDER BY datePlayed ASC")
     suspend fun pendingAnalysisGameIds(): List<Long>
 

--- a/app/src/main/java/com/raichess/data/database/PracticeDao.kt
+++ b/app/src/main/java/com/raichess/data/database/PracticeDao.kt
@@ -1,0 +1,33 @@
+package com.raichess.data.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+interface PracticeDao {
+
+    @Query("SELECT * FROM practice_positions ORDER BY createdAt DESC")
+    suspend fun getAll(): List<PracticePositionEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(positions: List<PracticePositionEntity>)
+
+    @Query("DELETE FROM practice_positions")
+    suspend fun clear()
+
+    /**
+     * Replace the whole stored list. The list is small by construction
+     * (PracticePositionStore caps it at 200), so list-level maintenance —
+     * FEN dedup, eviction — stays in the already-tested
+     * [com.raichess.domain.model.PracticePositionStore] instead of being
+     * reimplemented in SQL.
+     */
+    @Transaction
+    suspend fun replaceAll(positions: List<PracticePositionEntity>) {
+        clear()
+        insertAll(positions)
+    }
+}

--- a/app/src/main/java/com/raichess/data/database/RaiChessDatabase.kt
+++ b/app/src/main/java/com/raichess/data/database/RaiChessDatabase.kt
@@ -8,6 +8,10 @@ import androidx.room.RoomDatabase
 /**
  * App database: game history, per-move analysis, and practice positions —
  * the storage layer of the coaching roadmap (TECHNICAL_PLAN.md Phase 1/3).
+ *
+ * NOTE for the next schema bump: there is deliberately no
+ * fallbackToDestructiveMigration() — this data is the user's game history,
+ * so version 2 must ship a real Migration or the app will crash on update.
  */
 @Database(
     entities = [GameEntity::class, PositionEntity::class, PracticePositionEntity::class],

--- a/app/src/main/java/com/raichess/data/database/RaiChessDatabase.kt
+++ b/app/src/main/java/com/raichess/data/database/RaiChessDatabase.kt
@@ -1,0 +1,34 @@
+package com.raichess.data.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+/**
+ * App database: game history, per-move analysis, and practice positions —
+ * the storage layer of the coaching roadmap (TECHNICAL_PLAN.md Phase 1/3).
+ */
+@Database(
+    entities = [GameEntity::class, PositionEntity::class, PracticePositionEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class RaiChessDatabase : RoomDatabase() {
+
+    abstract fun gameDao(): GameDao
+    abstract fun practiceDao(): PracticeDao
+
+    companion object {
+        @Volatile private var instance: RaiChessDatabase? = null
+
+        fun get(context: Context): RaiChessDatabase =
+            instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    RaiChessDatabase::class.java,
+                    "raichess.db"
+                ).build().also { instance = it }
+            }
+    }
+}

--- a/app/src/main/java/com/raichess/data/engine/ChessEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/ChessEngine.kt
@@ -2,6 +2,7 @@ package com.raichess.data.engine
 
 import com.github.bhlangonijr.chesslib.Board
 import com.github.bhlangonijr.chesslib.move.Move
+import com.raichess.domain.model.PositionAnalysis
 
 /**
  * A chess opponent. Implemented by the pure-Kotlin [RaiEngine] (weak/beginner
@@ -24,6 +25,20 @@ interface ChessEngine {
      * by driving the engine from a single coroutine.
      */
     fun selectMove(board: Board): Move?
+
+    /**
+     * Evaluate the position on [board] at full strength: score for the side
+     * to move plus the best continuation found. Returns null when analysis
+     * is unavailable (no legal moves, or the implementation cannot analyze).
+     *
+     * Unlike [selectMove] this is never strength-limited — it powers
+     * post-game analysis and coaching, where an honest eval is the point.
+     * Same threading contract as [selectMove]: single sequential caller, off
+     * the UI thread, and [board] is left in its original state.
+     *
+     * @param moveTimeMs search budget; fixed-depth implementations may ignore it
+     */
+    fun analyze(board: Board, moveTimeMs: Long): PositionAnalysis? = null
 
     /**
      * Short human-readable label for the engine currently producing moves,

--- a/app/src/main/java/com/raichess/data/engine/EngineFactory.kt
+++ b/app/src/main/java/com/raichess/data/engine/EngineFactory.kt
@@ -28,4 +28,18 @@ object EngineFactory {
             RaiEngine(targetElo)
         }
     }
+
+    /**
+     * Full-strength analyzer for post-game analysis and coaching: Stockfish
+     * with no skill limiting, falling back to RaiEngine's fixed-depth
+     * analysis if the WASM/WebView bridge fails. Callers own the instance
+     * and must [ChessEngine.close] it when the analysis run is done.
+     */
+    fun createAnalyzer(context: Context): ChessEngine =
+        StockfishWasmEngine(
+            context,
+            targetElo = RaiEngine.MAX_ELO,
+            fallback = RaiEngine(RaiEngine.MAX_ELO),
+            analysisMode = true
+        )
 }

--- a/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
@@ -236,7 +236,10 @@ class RaiEngine(
         // Scores within this many points of MATE_SCORE are mate scores; the
         // ply distance is far smaller than this at any reachable depth.
         private const val MATE_PLY_WINDOW = 1000
-        /** Fixed search depth for [analyze]; deeper than most play bands but still phone-fast. */
+        // Fixed search depth for analyze(). 3 plies only sees immediate
+        // tactics (hanging pieces, one-move threats) — acceptable for a
+        // fallback that exists so analysis degrades rather than disappears
+        // when the Stockfish WASM bridge is unavailable.
         const val ANALYZE_DEPTH = 3
 
         // Piece-square tables (white perspective, rank 8 first)

--- a/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
@@ -7,6 +7,7 @@ import com.github.bhlangonijr.chesslib.Side
 import com.github.bhlangonijr.chesslib.Square
 import com.github.bhlangonijr.chesslib.move.Move
 import com.github.bhlangonijr.chesslib.move.MoveGenerator
+import com.raichess.domain.model.PositionAnalysis
 import kotlin.math.max
 import kotlin.random.Random
 
@@ -102,6 +103,60 @@ class RaiEngine(
         return candidates[random.nextInt(candidates.size)].first
     }
 
+    /**
+     * Full-strength analysis regardless of this engine's target ELO: a plain
+     * fixed-depth alpha-beta over the root with no blunder roll and no
+     * candidate window. Serves as the offline fallback analyzer when the
+     * Stockfish WASM bridge is unavailable — coarse (depth [ANALYZE_DEPTH],
+     * material + piece-square eval) but honest. [moveTimeMs] is ignored:
+     * this search is depth-bound, not time-bound.
+     */
+    override fun analyze(board: Board, moveTimeMs: Long): PositionAnalysis? {
+        val legalMoves = MoveGenerator.generateLegalMoves(board)
+        if (legalMoves.isEmpty()) return null
+
+        var bestMove: Move? = null
+        var bestScore = -INFINITY
+        var alpha = -INFINITY
+        for (move in legalMoves.sortedByDescending { captureValue(board, it) }) {
+            board.doMove(move)
+            val score = -negamax(board, ANALYZE_DEPTH - 1, -INFINITY, -alpha, 1)
+            board.undoMove()
+            if (score > bestScore) {
+                bestScore = score
+                bestMove = move
+            }
+            alpha = max(alpha, score)
+        }
+
+        val mateIn = mateInMoves(bestScore)
+        val bestLan = bestMove?.toString()?.lowercase()
+        return PositionAnalysis(
+            scoreCp = if (mateIn == null) bestScore else null,
+            mateIn = mateIn,
+            bestMoveLan = bestLan,
+            pv = listOfNotNull(bestLan),
+            depth = ANALYZE_DEPTH
+        )
+    }
+
+    /**
+     * Convert a root negamax score into moves-to-mate, or null for a
+     * non-mate score. Mate scores are MATE_SCORE minus the mating ply (see
+     * [negamax]), so the ply count is recoverable from the magnitude.
+     */
+    private fun mateInMoves(score: Int): Int? {
+        if (score > MATE_SCORE - MATE_PLY_WINDOW) {
+            val plies = MATE_SCORE - score
+            return (plies + 1) / 2
+        }
+        if (score < -(MATE_SCORE - MATE_PLY_WINDOW)) {
+            val plies = MATE_SCORE + score
+            return -((plies + 1) / 2)
+        }
+        return null
+    }
+
     private fun negamax(board: Board, depth: Int, alphaIn: Int, beta: Int, ply: Int): Int {
         if (board.isMated) return -(MATE_SCORE - ply)
         if (board.isDraw) return 0
@@ -178,6 +233,11 @@ class RaiEngine(
         const val MAX_ELO = 2800
         private const val INFINITY = 1_000_000
         private const val MATE_SCORE = 100_000
+        // Scores within this many points of MATE_SCORE are mate scores; the
+        // ply distance is far smaller than this at any reachable depth.
+        private const val MATE_PLY_WINDOW = 1000
+        /** Fixed search depth for [analyze]; deeper than most play bands but still phone-fast. */
+        const val ANALYZE_DEPTH = 3
 
         // Piece-square tables (white perspective, rank 8 first)
         private val PAWN_TABLE = intArrayOf(

--- a/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
@@ -118,8 +118,11 @@ class StockfishWasmEngine(
             if (released) return null
 
             output.clear()
-            // No ucinewgame between positions of the same game: a warm hash
-            // makes sequential post-game analysis faster and no less exact.
+            // No ucinewgame between analyze() calls — including across
+            // different games when one engine drains a backlog: the
+            // transposition table is keyed by position, so entries from
+            // another game are irrelevant or helpful, never wrong, and a
+            // warm hash makes sequential analysis faster.
             send("position fen ${board.fen}")
             send("go movetime $moveTimeMs")
 

--- a/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
@@ -16,6 +16,7 @@ import com.github.bhlangonijr.chesslib.Board
 import com.github.bhlangonijr.chesslib.move.Move
 import com.github.bhlangonijr.chesslib.move.MoveGenerator
 import com.raichess.domain.model.EloConfiguration
+import com.raichess.domain.model.PositionAnalysis
 import org.json.JSONObject
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -33,7 +34,13 @@ import java.util.concurrent.TimeUnit
 class StockfishWasmEngine(
     context: Context,
     targetElo: Int,
-    private val fallback: ChessEngine
+    private val fallback: ChessEngine,
+    /**
+     * When true this instance is an analyzer, not an opponent: the
+     * skill-limiting UCI options are never sent, so searches run at full
+     * strength. Use [EngineFactory.createAnalyzer] to obtain one.
+     */
+    private val analysisMode: Boolean = false
 ) : ChessEngine {
 
     private val appContext = context.applicationContext
@@ -98,6 +105,65 @@ class StockfishWasmEngine(
         }
     }
 
+    /**
+     * Full-strength evaluation of [board]: runs a normal search and keeps
+     * the deepest exact-score `info` line seen before `bestmove`. Falls back
+     * to [fallback]'s (coarser) analysis if the WASM bridge is unavailable.
+     *
+     * Same single-caller contract as [selectMove] — both share [output].
+     */
+    override fun analyze(board: Board, moveTimeMs: Long): PositionAnalysis? {
+        return try {
+            if (!ensureReady()) return fallbackAnalysis(board, moveTimeMs)
+            if (released) return null
+
+            output.clear()
+            // No ucinewgame between positions of the same game: a warm hash
+            // makes sequential post-game analysis faster and no less exact.
+            send("position fen ${board.fen}")
+            send("go movetime $moveTimeMs")
+
+            // Track the best info line while waiting for the bestmove
+            // terminator. Bound scores (fail-high/low) are only reported
+            // mid-resolution, so exact scores are preferred; multipv is
+            // always 1 here but filtered defensively for when hints add
+            // MultiPV search.
+            var lastInfo: UciInfoParser.UciInfo? = null
+            val best = awaitToken(moveTimeMs + BESTMOVE_GRACE_MS) { line ->
+                UciInfoParser.parse(line)?.let { info ->
+                    if (info.multipv == 1 && !info.isBound) lastInfo = info
+                }
+                line.startsWith("bestmove")
+            }
+            if (best == null) {
+                if (released) return null
+                Log.w(TAG, "no bestmove within analysis timeout; using fallback analyzer")
+                return fallbackAnalysis(board, moveTimeMs)
+            }
+
+            val info = lastInfo ?: return fallbackAnalysis(board, moveTimeMs)
+            // Re-validate the engine's move against the real legal set, as
+            // selectMove does; "bestmove (none)" (mate/stalemate) → null.
+            val bestMoveLan = parseUciBestMove(board, best)?.toString()?.lowercase()
+            PositionAnalysis(
+                scoreCp = info.scoreCp,
+                mateIn = info.scoreMate,
+                bestMoveLan = bestMoveLan,
+                pv = info.pv.map { it.lowercase() },
+                depth = info.depth
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "analyze failed; using fallback analyzer", e)
+            fallbackAnalysis(board, moveTimeMs)
+        }
+    }
+
+    /** Serve an analysis from the RaiEngine fallback and remember that we did. */
+    private fun fallbackAnalysis(board: Board, moveTimeMs: Long): PositionAnalysis? {
+        everFellBack = true
+        return fallback.analyze(board, moveTimeMs)
+    }
+
     /** Serve a move from the RaiEngine fallback and remember that we did. */
     private fun fallbackMove(board: Board): Move? {
         everFellBack = true
@@ -124,8 +190,12 @@ class StockfishWasmEngine(
 
         // Apply strength for this ELO. The bundled SF10 build only supports
         // `Skill Level` (UCI_Elo/UCI_LimitStrength came in SF11), so
-        // getUciCommands() sends just that — see EloConfiguration.
-        config.getUciCommands().forEach { send(it) }
+        // getUciCommands() sends just that — see EloConfiguration. Analyzers
+        // stay at full strength: an eval from a skill-capped search would
+        // misgrade the player's moves.
+        if (!analysisMode) {
+            config.getUciCommands().forEach { send(it) }
+        }
         send("setoption name Threads value 1")
         send("setoption name Hash value 16")
         if (!isReady()) return fail("engine not ready after options")

--- a/app/src/main/java/com/raichess/data/engine/UciInfoParser.kt
+++ b/app/src/main/java/com/raichess/data/engine/UciInfoParser.kt
@@ -1,0 +1,69 @@
+package com.raichess.data.engine
+
+/**
+ * Parses UCI `info` lines from a search into the fields the analysis
+ * pipeline needs. Pure string handling — unit-testable without a WebView.
+ */
+object UciInfoParser {
+
+    /**
+     * One parsed `info` line. Exactly one of [scoreCp]/[scoreMate] is
+     * non-null (that's the precondition for [parse] returning non-null).
+     */
+    data class UciInfo(
+        val depth: Int,
+        /** MultiPV rank; UCI omits the token for single-PV search, so 1. */
+        val multipv: Int,
+        val scoreCp: Int?,
+        val scoreMate: Int?,
+        /** True for `lowerbound`/`upperbound` scores (fail-high/low, not exact). */
+        val isBound: Boolean,
+        /** Principal variation in LAN as reported, possibly empty. */
+        val pv: List<String>
+    )
+
+    /**
+     * Parse a single engine output line. Returns null for anything that is
+     * not an `info` line carrying a score — those are the only lines the
+     * analyzer cares about.
+     */
+    fun parse(line: String): UciInfo? {
+        val tokens = line.trim().split(Regex("\\s+"))
+        if (tokens.firstOrNull() != "info") return null
+
+        var depth = 0
+        var multipv = 1
+        var scoreCp: Int? = null
+        var scoreMate: Int? = null
+        var isBound = false
+        var pv: List<String> = emptyList()
+
+        var i = 1
+        while (i < tokens.size) {
+            when (tokens[i]) {
+                "depth" -> depth = tokens.getOrNull(i + 1)?.toIntOrNull() ?: 0
+                "multipv" -> multipv = tokens.getOrNull(i + 1)?.toIntOrNull() ?: 1
+                "score" -> {
+                    when (tokens.getOrNull(i + 1)) {
+                        "cp" -> scoreCp = tokens.getOrNull(i + 2)?.toIntOrNull()
+                        "mate" -> scoreMate = tokens.getOrNull(i + 2)?.toIntOrNull()
+                    }
+                    if (tokens.getOrNull(i + 3) == "lowerbound" ||
+                        tokens.getOrNull(i + 3) == "upperbound"
+                    ) {
+                        isBound = true
+                    }
+                }
+                // pv is always the last field on an info line, so consume the rest
+                "pv" -> {
+                    pv = tokens.subList(i + 1, tokens.size)
+                    i = tokens.size
+                }
+            }
+            i++
+        }
+
+        if (scoreCp == null && scoreMate == null) return null
+        return UciInfo(depth, multipv, scoreCp, scoreMate, isBound, pv)
+    }
+}

--- a/app/src/main/java/com/raichess/data/repository/GameRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/GameRepository.kt
@@ -1,0 +1,72 @@
+package com.raichess.data.repository
+
+import android.content.Context
+import com.raichess.data.database.AnalysisState
+import com.raichess.data.database.GameEntity
+import com.raichess.data.database.PositionEntity
+import com.raichess.data.database.RaiChessDatabase
+import com.raichess.domain.model.CompletedGame
+import com.raichess.domain.usecase.GameAnalyzer
+
+/**
+ * Room-backed game history: finished games plus their per-move analysis.
+ * Games are written immediately at game over (analysisState PENDING); the
+ * analysis pass fills in positions and accuracy afterwards.
+ */
+class GameRepository(context: Context) {
+
+    private val dao = RaiChessDatabase.get(context).gameDao()
+
+    /** Persist a finished game; returns its row id for the analysis pass. */
+    suspend fun saveCompletedGame(game: CompletedGame): Long =
+        dao.insertGame(
+            GameEntity(
+                pgn = game.pgn,
+                movesLan = game.movesLan.joinToString(" "),
+                datePlayed = game.datePlayed,
+                result = game.result.toPgnResult(game.playerColor),
+                playerColor = game.playerColor.name,
+                opponentElo = game.opponentElo,
+                playerEloBefore = game.playerEloBefore,
+                playerEloAfter = game.playerEloAfter,
+                gameMode = game.gameMode.name,
+                undoCount = game.undoCount,
+                accuracy = null,
+                analysisState = AnalysisState.PENDING,
+                createdAt = System.currentTimeMillis()
+            )
+        )
+
+    suspend fun getGame(gameId: Long): GameEntity? = dao.getGame(gameId)
+
+    suspend fun recentGames(limit: Int = 50): List<GameEntity> = dao.recentGames(limit)
+
+    suspend fun positionsForGame(gameId: Long): List<PositionEntity> =
+        dao.positionsForGame(gameId)
+
+    /** Games saved but not yet (successfully) analyzed, oldest first. */
+    suspend fun pendingAnalysisGameIds(): List<Long> = dao.pendingAnalysisGameIds()
+
+    suspend fun recordAnalysis(gameId: Long, report: GameAnalyzer.GameReport) {
+        val rows = report.moves.map { move ->
+            PositionEntity(
+                gameId = gameId,
+                ply = move.ply,
+                fen = move.fen,
+                evaluationCp = move.evaluationCp,
+                bestMove = move.bestMoveLan,
+                movePlayed = move.movePlayedLan,
+                isPlayerMove = move.isPlayerMove,
+                centipawnLoss = move.centipawnLoss,
+                classification = move.classification?.name,
+                analysisDepth = move.depth,
+                analyzerVersion = GameAnalyzer.VERSION
+            )
+        }
+        dao.recordAnalysis(gameId, rows, report.accuracy)
+    }
+
+    suspend fun markAnalysisFailed(gameId: Long) {
+        dao.setAnalysisResult(gameId, accuracy = null, state = AnalysisState.FAILED)
+    }
+}

--- a/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
@@ -5,55 +5,102 @@ import android.content.SharedPreferences
 import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.reflect.TypeToken
+import com.raichess.data.database.RaiChessDatabase
+import com.raichess.data.database.toDomain
+import com.raichess.data.database.toEntity
 import com.raichess.domain.model.PracticeCategory
 import com.raichess.domain.model.PracticePosition
 import com.raichess.domain.model.PracticePositionStore
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.UUID
 
 /**
  * Persists practice positions extracted from play (currently:
  * Training-mode undos as MISTAKE_CORRECTION entries).
  *
- * SharedPreferences + Gson for the MVP; the PracticePosition schema
- * mirrors the practice_positions table in TECHNICAL_PLAN.md so the
- * planned Room migration is a field-for-field mapping.
+ * Room-backed (practice_positions), completing the migration the
+ * SharedPreferences MVP was staged for: the legacy JSON blob, if present,
+ * is imported once on first access and the schema is field-for-field the
+ * old [PracticePosition]. List maintenance (FEN dedup, the 200-entry cap)
+ * stays in the pure, tested [PracticePositionStore].
  */
 class PracticeRepository(context: Context) {
 
+    private val appContext = context.applicationContext
+    private val dao = RaiChessDatabase.get(appContext).practiceDao()
     private val prefs: SharedPreferences =
-        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    private val gson = Gson()
-    private val listType = object : TypeToken<List<PracticePosition>>() {}.type
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    // Serializes read-merge-write updates from concurrent callers
+    private val writeMutex = Mutex()
 
-    fun getPositions(): List<PracticePosition> {
-        val json = prefs.getString(KEY_POSITIONS, null) ?: return emptyList()
-        return try {
-            gson.fromJson<List<PracticePosition>>(json, listType) ?: emptyList()
-        } catch (e: JsonParseException) {
-            // Fail closed on any corrupt/incompatible persisted JSON so a
-            // bad prefs blob can't crash the setup screen on load
-            emptyList()
-        }
+    suspend fun getPositions(): List<PracticePosition> {
+        importLegacyIfNeeded()
+        return dao.getAll().map { it.toDomain() }
     }
 
     /**
      * Record the position a Training-mode undo rolled back to — the board
      * as it stood before the player's mistaken move.
+     *
+     * @param sourceGameId row id in the games table, when known. Undo-time
+     *   captures pass null: the game row is only created at game over.
      */
-    fun addMistakePosition(fen: String, sourceMoveNumber: Int) {
+    suspend fun addMistakePosition(
+        fen: String,
+        sourceMoveNumber: Int,
+        sourceGameId: Long? = null
+    ) {
+        importLegacyIfNeeded()
         val position = PracticePosition(
             id = UUID.randomUUID().toString(),
+            sourceGameId = sourceGameId,
             sourceMoveNumber = sourceMoveNumber,
             fen = fen,
             category = PracticeCategory.MISTAKE_CORRECTION,
             createdAt = System.currentTimeMillis()
         )
-        val updated = PracticePositionStore.withPosition(getPositions(), position)
-        prefs.edit().putString(KEY_POSITIONS, gson.toJson(updated, listType)).apply()
+        writeMutex.withLock {
+            val updated = PracticePositionStore.withPosition(
+                dao.getAll().map { it.toDomain() },
+                position
+            )
+            dao.replaceAll(updated.map { it.toEntity() })
+        }
+    }
+
+    /**
+     * One-time import of the pre-Room SharedPreferences store. The flag is
+     * set even when the blob is absent or corrupt — either way there will
+     * never be anything (more) to import.
+     */
+    private suspend fun importLegacyIfNeeded() {
+        if (prefs.getBoolean(KEY_MIGRATED, false)) return
+        writeMutex.withLock {
+            if (prefs.getBoolean(KEY_MIGRATED, false)) return
+            val json = prefs.getString(KEY_POSITIONS, null)
+            if (json != null) {
+                val legacy = try {
+                    val listType = object : TypeToken<List<PracticePosition>>() {}.type
+                    Gson().fromJson<List<PracticePosition>>(json, listType) ?: emptyList()
+                } catch (e: JsonParseException) {
+                    // Fail closed on a corrupt blob, exactly as the old store did
+                    emptyList()
+                }
+                if (legacy.isNotEmpty()) {
+                    dao.insertAll(legacy.map { it.toEntity() })
+                }
+            }
+            prefs.edit()
+                .putBoolean(KEY_MIGRATED, true)
+                .remove(KEY_POSITIONS)
+                .apply()
+        }
     }
 
     companion object {
         private const val PREFS_NAME = "raichess_practice"
         private const val KEY_POSITIONS = "positions"
+        private const val KEY_MIGRATED = "migrated_to_room"
     }
 }

--- a/app/src/main/java/com/raichess/domain/model/CompletedGame.kt
+++ b/app/src/main/java/com/raichess/domain/model/CompletedGame.kt
@@ -1,0 +1,74 @@
+package com.raichess.domain.model
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Everything worth persisting about a finished game, captured at the moment
+ * the result is recorded. [movesLan] is kept alongside the PGN so the
+ * analysis pipeline can replay the game without a PGN parser, and so stored
+ * games can be re-analyzed later (e.g. at higher depth) from raw moves.
+ */
+data class CompletedGame(
+    val pgn: String,
+    /** Every ply in lowercase LAN ("e2e4"), in play order. */
+    val movesLan: List<String>,
+    /** Outcome from the player's perspective. */
+    val result: GameResult,
+    val playerColor: PlayerColor,
+    val opponentElo: Int,
+    val playerEloBefore: Int,
+    val playerEloAfter: Int,
+    val gameMode: GameMode,
+    /** Training-mode undos used (0 in Rated). */
+    val undoCount: Int,
+    val datePlayed: Long
+)
+
+/**
+ * Builds a minimal, valid PGN for a finished RaiChess game. Pure string
+ * assembly — unit-testable without Android or chesslib.
+ */
+object PgnBuilder {
+
+    fun build(
+        sanMoves: List<String>,
+        result: GameResult,
+        playerColor: PlayerColor,
+        opponentElo: Int,
+        datePlayed: Long
+    ): String {
+        val resultTag = result.toPgnResult(playerColor)
+        val date = SimpleDateFormat("yyyy.MM.dd", Locale.US).format(Date(datePlayed))
+        val ai = "RaiChess AI ($opponentElo)"
+        val white = if (playerColor == PlayerColor.WHITE) "Player" else ai
+        val black = if (playerColor == PlayerColor.BLACK) "Player" else ai
+
+        val moveText = buildString {
+            sanMoves.forEachIndexed { index, san ->
+                if (index % 2 == 0) {
+                    if (index > 0) append(' ')
+                    append(index / 2 + 1).append(". ")
+                } else {
+                    append(' ')
+                }
+                append(san)
+            }
+            if (sanMoves.isNotEmpty()) append(' ')
+            append(resultTag)
+        }
+
+        return buildString {
+            appendLine("[Event \"RaiChess\"]")
+            appendLine("[Site \"RaiChess (offline)\"]")
+            appendLine("[Date \"$date\"]")
+            appendLine("[Round \"-\"]")
+            appendLine("[White \"$white\"]")
+            appendLine("[Black \"$black\"]")
+            appendLine("[Result \"$resultTag\"]")
+            appendLine()
+            append(moveText)
+        }
+    }
+}

--- a/app/src/main/java/com/raichess/domain/model/EloCalculator.kt
+++ b/app/src/main/java/com/raichess/domain/model/EloCalculator.kt
@@ -94,6 +94,13 @@ enum class GameResult {
     DRAW,
     LOSS;
 
+    /** Inverse of [fromPgnResult]: the PGN result tag for this outcome. */
+    fun toPgnResult(playerColor: PlayerColor): String = when (this) {
+        DRAW -> "1/2-1/2"
+        WIN -> if (playerColor == PlayerColor.WHITE) "1-0" else "0-1"
+        LOSS -> if (playerColor == PlayerColor.WHITE) "0-1" else "1-0"
+    }
+
     companion object {
         fun fromPgnResult(result: String, playerColor: PlayerColor): GameResult {
             return when (result) {

--- a/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
+++ b/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
@@ -1,0 +1,61 @@
+package com.raichess.domain.model
+
+import kotlin.math.max
+
+/**
+ * Quality verdict for a single played move, per the thresholds in
+ * TECHNICAL_PLAN.md §B (Game Analysis Algorithm).
+ */
+enum class MoveClassification {
+    /** The engine's own first choice. */
+    BEST,
+    /** Within 0.3 pawns of best. */
+    GOOD,
+    /** 0.3–1.0 pawn loss. */
+    INACCURACY,
+    /** 1.0–3.0 pawn loss. */
+    MISTAKE,
+    /** 3.0+ pawn loss. */
+    BLUNDER
+}
+
+/**
+ * Pure move-quality math shared by post-game analysis (and, later, live
+ * coaching): centipawn loss, classification thresholds, and the
+ * accuracy-from-ACPL formula. Kept free of Android/engine types so it is
+ * trivially unit-testable and the thresholds live in exactly one place.
+ */
+object MoveClassifier {
+
+    /** Mate scores and runaway evals are clamped to ±this before loss math. */
+    const val EVAL_CAP_CP = 1000
+
+    private const val INACCURACY_THRESHOLD_CP = 30
+    private const val MISTAKE_THRESHOLD_CP = 100
+    private const val BLUNDER_THRESHOLD_CP = 300
+
+    /**
+     * Centipawns thrown away by a move, never negative. Both arguments are
+     * from the mover's perspective and already capped (see
+     * [PositionAnalysis.effectiveCp]): the eval before the move, and the eval
+     * of the resulting position negated back to the mover's point of view.
+     */
+    fun centipawnLoss(evalBeforeCp: Int, evalAfterCp: Int): Int =
+        max(0, evalBeforeCp - evalAfterCp)
+
+    fun classify(centipawnLoss: Int, playedEngineBest: Boolean): MoveClassification = when {
+        playedEngineBest -> MoveClassification.BEST
+        centipawnLoss < INACCURACY_THRESHOLD_CP -> MoveClassification.GOOD
+        centipawnLoss < MISTAKE_THRESHOLD_CP -> MoveClassification.INACCURACY
+        centipawnLoss < BLUNDER_THRESHOLD_CP -> MoveClassification.MISTAKE
+        else -> MoveClassification.BLUNDER
+    }
+
+    /**
+     * Accuracy percentage from average centipawn loss. Linear and deliberately
+     * simple: 0 ACPL = 100%, 100 ACPL (a mistake every move) = 75%, floor at
+     * 0. Feeds [EloCalculator]'s moveAccuracy input, where 50 is neutral.
+     */
+    fun accuracyFromAcpl(acplCp: Double): Double =
+        max(0.0, 100.0 - acplCp * 0.25)
+}

--- a/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
+++ b/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
@@ -55,6 +55,10 @@ object MoveClassifier {
      * Accuracy percentage from average centipawn loss. Linear and deliberately
      * simple: 0 ACPL = 100%, 100 ACPL (a mistake every move) = 75%, floor at
      * 0. Feeds [EloCalculator]'s moveAccuracy input, where 50 is neutral.
+     *
+     * Intentionally gentler than TECHNICAL_PLAN.md's original `100 - ACPL`
+     * draft, which hit 0% at one pawn of average loss — the plan doc has been
+     * updated to match this coefficient.
      */
     fun accuracyFromAcpl(acplCp: Double): Double =
         max(0.0, 100.0 - acplCp * 0.25)

--- a/app/src/main/java/com/raichess/domain/model/PositionAnalysis.kt
+++ b/app/src/main/java/com/raichess/domain/model/PositionAnalysis.kt
@@ -1,0 +1,34 @@
+package com.raichess.domain.model
+
+/**
+ * An engine's verdict on a single position: the evaluation for the side to
+ * move plus the best continuation it found. Produced by
+ * [com.raichess.data.engine.ChessEngine.analyze].
+ *
+ * Exactly one of [scoreCp] / [mateIn] is non-null (UCI reports one or the
+ * other). Both are from the side-to-move's perspective: positive means the
+ * side to move is better / delivering mate.
+ */
+data class PositionAnalysis(
+    /** Evaluation in centipawns, side-to-move perspective. */
+    val scoreCp: Int?,
+    /** Moves until mate (positive: side to move mates; negative: gets mated). */
+    val mateIn: Int?,
+    /** Best move in lowercase LAN (e.g. "e2e4", "e7e8q"), null if none. */
+    val bestMoveLan: String?,
+    /** Principal variation in LAN, starting with [bestMoveLan]. May be empty. */
+    val pv: List<String> = emptyList(),
+    /** Search depth the verdict came from. */
+    val depth: Int = 0
+) {
+    /**
+     * The evaluation as a bounded centipawn number, mapping mate scores to
+     * ±[cap]. Capping keeps centipawn-loss math meaningful: a swing from a
+     * +40000 mate score to +900 is not a 391-pawn blunder.
+     */
+    fun effectiveCp(cap: Int = MoveClassifier.EVAL_CAP_CP): Int = when {
+        mateIn != null -> if (mateIn > 0) cap else -cap
+        scoreCp != null -> scoreCp.coerceIn(-cap, cap)
+        else -> 0
+    }
+}

--- a/app/src/main/java/com/raichess/domain/usecase/GameAnalyzer.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/GameAnalyzer.kt
@@ -1,0 +1,147 @@
+package com.raichess.domain.usecase
+
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.Side
+import com.github.bhlangonijr.chesslib.move.Move
+import com.github.bhlangonijr.chesslib.move.MoveGenerator
+import com.raichess.data.engine.ChessEngine
+import com.raichess.domain.model.MoveClassification
+import com.raichess.domain.model.MoveClassifier
+import com.raichess.domain.model.PositionAnalysis
+
+/**
+ * Post-game analysis (TECHNICAL_PLAN.md §B): replays a finished game,
+ * evaluates every position with the injected engine, and grades the
+ * player's moves — centipawn loss, classification, and overall accuracy.
+ *
+ * Pure domain logic: the engine is injected, so tests drive it with a
+ * scripted fake and production wires in the Stockfish analyzer. Runs
+ * synchronously on the caller's (background) thread, respecting the
+ * engine's single-caller contract.
+ */
+class GameAnalyzer(
+    private val engine: ChessEngine,
+    private val moveTimeMs: Long = DEFAULT_MOVE_TIME_MS
+) {
+
+    /** The engine's verdict on one played ply. */
+    data class MoveReport(
+        val ply: Int,
+        /** FEN before the move. */
+        val fen: String,
+        /** True when White was to move at [ply]. */
+        val whiteToMove: Boolean,
+        val movePlayedLan: String,
+        val isPlayerMove: Boolean,
+        /** Eval of [fen] in capped centipawns, White's perspective. */
+        val evaluationCp: Int,
+        val bestMoveLan: String?,
+        /** Player moves only; null for the AI's plies. */
+        val centipawnLoss: Int?,
+        val classification: MoveClassification?,
+        val depth: Int
+    )
+
+    data class GameReport(
+        val moves: List<MoveReport>,
+        /** Average centipawn loss over the player's moves. */
+        val acpl: Double,
+        /** 0–100; [MoveClassifier.accuracyFromAcpl] of [acpl]. */
+        val accuracy: Double
+    )
+
+    /**
+     * Analyze a game given its plies in LAN. Returns null if any move fails
+     * to replay or any position fails to analyze — a partial grade would
+     * misstate the player's accuracy, so the caller marks the game FAILED
+     * and can retry later.
+     */
+    fun analyze(movesLan: List<String>, playerIsWhite: Boolean): GameReport? {
+        if (movesLan.isEmpty()) return null
+
+        // Pass 1: replay the game, evaluating each position before its move.
+        data class Step(
+            val fen: String,
+            val whiteToMove: Boolean,
+            val analysis: PositionAnalysis,
+            val moveLan: String
+        )
+
+        val board = Board()
+        val steps = ArrayList<Step>(movesLan.size)
+        for (lan in movesLan) {
+            val analysis = engine.analyze(board, moveTimeMs) ?: return null
+            val move = lanToLegalMove(board, lan) ?: return null
+            steps.add(Step(board.fen, board.sideToMove == Side.WHITE, analysis, lan))
+            board.doMove(move)
+        }
+
+        // Eval after the final move, from the final side-to-move's view.
+        // Terminal positions have no moves to search, so score them directly.
+        val finalEvalStm = when {
+            board.isMated -> -MoveClassifier.EVAL_CAP_CP
+            board.isDraw -> 0
+            else -> engine.analyze(board, moveTimeMs)?.effectiveCp() ?: return null
+        }
+
+        // Pass 2: grade each move by the eval swing it caused.
+        val reports = steps.mapIndexed { i, step ->
+            val evalBeforeStm = step.analysis.effectiveCp()
+            // The next position's eval is from the opponent's perspective;
+            // negate it back to the mover's to measure what the move cost.
+            val evalAfterNextStm =
+                if (i + 1 < steps.size) steps[i + 1].analysis.effectiveCp() else finalEvalStm
+            val loss = MoveClassifier.centipawnLoss(evalBeforeStm, -evalAfterNextStm)
+
+            val isPlayerMove = step.whiteToMove == playerIsWhite
+            val playedBest = step.moveLan.lowercase() == step.analysis.bestMoveLan?.lowercase()
+
+            MoveReport(
+                ply = i,
+                fen = step.fen,
+                whiteToMove = step.whiteToMove,
+                movePlayedLan = step.moveLan.lowercase(),
+                isPlayerMove = isPlayerMove,
+                evaluationCp = if (step.whiteToMove) evalBeforeStm else -evalBeforeStm,
+                bestMoveLan = step.analysis.bestMoveLan,
+                centipawnLoss = if (isPlayerMove) loss else null,
+                classification = if (isPlayerMove) MoveClassifier.classify(loss, playedBest) else null,
+                depth = step.analysis.depth
+            )
+        }
+
+        val playerLosses = reports.mapNotNull { it.centipawnLoss }
+        // No player moves (e.g. an immediate resign as Black): nothing to
+        // grade, so report neutral accuracy rather than a perfect 100.
+        val acpl = if (playerLosses.isEmpty()) null else playerLosses.average()
+        return GameReport(
+            moves = reports,
+            acpl = acpl ?: 0.0,
+            accuracy = acpl?.let { MoveClassifier.accuracyFromAcpl(it) } ?: NEUTRAL_ACCURACY
+        )
+    }
+
+    companion object {
+        /**
+         * Bump when the analysis semantics change (thresholds, eval
+         * conventions, tagging) so stored rows can be found and re-analyzed.
+         */
+        const val VERSION = 1
+
+        /** Per-position budget: deep enough to grade honestly, ~15s for a 60-ply game. */
+        const val DEFAULT_MOVE_TIME_MS = 250L
+
+        private const val NEUTRAL_ACCURACY = 50.0
+
+        /**
+         * Resolve a LAN string against the actual legal moves (same
+         * validation approach as StockfishWasmEngine.parseUciBestMove), so a
+         * corrupt stored move can never be force-applied.
+         */
+        fun lanToLegalMove(board: Board, lan: String): Move? {
+            val wanted = lan.lowercase()
+            return MoveGenerator.generateLegalMoves(board)
+                .firstOrNull { it.toString().lowercase() == wanted }
+        }
+    }
+}

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -12,16 +12,19 @@ import com.github.bhlangonijr.chesslib.move.Move
 import com.github.bhlangonijr.chesslib.move.MoveConversionException
 import com.github.bhlangonijr.chesslib.move.MoveGenerator
 import com.github.bhlangonijr.chesslib.move.MoveList
+import com.raichess.data.analysis.AnalysisCoordinator
 import com.raichess.data.engine.ChessEngine
 import com.raichess.data.engine.EngineFactory
 import com.raichess.data.engine.RaiEngine
 import com.raichess.data.repository.PlayerProfileRepository
 import com.raichess.data.repository.PracticeRepository
 import com.raichess.data.repository.SettingsRepository
+import com.raichess.domain.model.CompletedGame
 import com.raichess.domain.model.EloConfiguration
 import com.raichess.domain.model.EloStats
 import com.raichess.domain.model.GameMode
 import com.raichess.domain.model.GameResult
+import com.raichess.domain.model.PgnBuilder
 import com.raichess.domain.model.PlayerColor
 import com.raichess.domain.model.UndoPenalty
 import com.raichess.domain.model.canUndo
@@ -218,10 +221,14 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
         gameUndoCount++
         repository.incrementLifetimeUndos()
-        practiceRepository.addMistakePosition(
-            fen = board.fen, // the position as it stood before the mistake
-            sourceMoveNumber = remaining.size / 2 + 1
-        )
+        // Snapshot now: the suspend write races further play on the live board
+        val preMistakeFen = board.fen
+        viewModelScope.launch {
+            practiceRepository.addMistakePosition(
+                fen = preMistakeFen, // the position as it stood before the mistake
+                sourceMoveNumber = remaining.size / 2 + 1
+            )
+        }
 
         _uiState.value = state.copy(
             squares = boardSnapshot(),
@@ -363,6 +370,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             UndoPenalty.NEUTRAL_ACCURACY
         }
         val (stats, delta) = repository.recordResult(result, state.opponentElo, accuracy)
+        persistFinishedGame(state, result, eloAfter = stats.currentElo, eloDelta = delta)
         _uiState.value = state.copy(
             phase = GamePhase.GAME_OVER,
             playerStats = stats,
@@ -371,6 +379,45 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             ending = ending,
             eloDelta = delta,
             canUndo = false
+        )
+    }
+
+    /**
+     * Persist the finished game and queue its background analysis
+     * (TECHNICAL_PLAN.md Phase 1/3). Fire-and-forget on an app-lifetime
+     * scope inside the coordinator, so leaving this screen can't lose the
+     * game or cancel its analysis. Games with no moves (an instant resign)
+     * have nothing to store or analyze and are skipped.
+     */
+    private fun persistFinishedGame(
+        state: GameUiState,
+        result: GameResult,
+        eloAfter: Int,
+        eloDelta: Int
+    ) {
+        val sanMoves = sanHistory()
+        if (sanMoves.isEmpty()) return
+        val now = System.currentTimeMillis()
+        AnalysisCoordinator.saveAndAnalyze(
+            getApplication(),
+            CompletedGame(
+                pgn = PgnBuilder.build(
+                    sanMoves = sanMoves,
+                    result = result,
+                    playerColor = state.playerColor,
+                    opponentElo = state.opponentElo,
+                    datePlayed = now
+                ),
+                movesLan = moveList.map { it.toString().lowercase() },
+                result = result,
+                playerColor = state.playerColor,
+                opponentElo = state.opponentElo,
+                playerEloBefore = eloAfter - eloDelta,
+                playerEloAfter = eloAfter,
+                gameMode = state.gameMode,
+                undoCount = gameUndoCount,
+                datePlayed = now
+            )
         )
     }
 

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -412,6 +412,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                 result = result,
                 playerColor = state.playerColor,
                 opponentElo = state.opponentElo,
+                // Relies on recordResult's delta being the exact signed
+                // change it applied (newElo - oldElo); revisit if that
+                // contract ever changes
                 playerEloBefore = eloAfter - eloDelta,
                 playerEloAfter = eloAfter,
                 gameMode = state.gameMode,

--- a/app/src/test/java/com/raichess/data/engine/RaiEngineAnalyzeTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/RaiEngineAnalyzeTest.kt
@@ -1,0 +1,50 @@
+package com.raichess.data.engine
+
+import com.github.bhlangonijr.chesslib.Board
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * RaiEngine.analyze is the offline fallback analyzer, so it must be honest
+ * (full strength, no blunder roll) even when the engine instance itself is
+ * configured as a weak opponent.
+ */
+class RaiEngineAnalyzeTest {
+
+    @Test
+    fun `finds a hanging queen at full strength even on a beginner instance`() {
+        // White rook on d2, black queen hanging on d5
+        val board = Board().apply { loadFromFen("k7/8/8/3q4/8/8/3R4/K7 w - - 0 1") }
+        val originalFen = board.fen
+
+        // Weakest band: selectMove would blunder 60% of the time — analyze must not
+        val analysis = RaiEngine(RaiEngine.MIN_ELO).analyze(board, moveTimeMs = 0)!!
+
+        assertEquals("d2d5", analysis.bestMoveLan)
+        assertTrue((analysis.scoreCp ?: 0) > 300 || analysis.mateIn != null)
+        assertEquals(RaiEngine.ANALYZE_DEPTH, analysis.depth)
+        assertEquals("board must be left untouched", originalFen, board.fen)
+    }
+
+    @Test
+    fun `reports mate in one`() {
+        // Rh8# — the b6 king covers the a7/b7 escape squares
+        val board = Board().apply { loadFromFen("k7/8/1K6/8/8/8/8/7R w - - 0 1") }
+        val analysis = RaiEngine(1200).analyze(board, moveTimeMs = 0)!!
+
+        assertEquals("h1h8", analysis.bestMoveLan)
+        assertEquals(1, analysis.mateIn)
+        assertNull(analysis.scoreCp)
+    }
+
+    @Test
+    fun `returns null on a terminal position`() {
+        // Fool's mate final position: White to move, checkmated
+        val board = Board().apply {
+            loadFromFen("rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w KQkq - 0 3")
+        }
+        assertNull(RaiEngine(1200).analyze(board, moveTimeMs = 0))
+    }
+}

--- a/app/src/test/java/com/raichess/data/engine/UciInfoParserTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/UciInfoParserTest.kt
@@ -1,0 +1,67 @@
+package com.raichess.data.engine
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UciInfoParserTest {
+
+    @Test
+    fun `parses a standard cp info line with pv`() {
+        val info = UciInfoParser.parse(
+            "info depth 18 seldepth 24 multipv 1 score cp 34 nodes 123456 nps 987654 time 1000 pv e2e4 e7e5 g1f3"
+        )!!
+        assertEquals(18, info.depth)
+        assertEquals(1, info.multipv)
+        assertEquals(34, info.scoreCp)
+        assertNull(info.scoreMate)
+        assertEquals(false, info.isBound)
+        assertEquals(listOf("e2e4", "e7e5", "g1f3"), info.pv)
+    }
+
+    @Test
+    fun `parses negative cp and mate scores`() {
+        val losing = UciInfoParser.parse("info depth 12 score cp -250 pv d7d5")!!
+        assertEquals(-250, losing.scoreCp)
+
+        val mating = UciInfoParser.parse("info depth 20 score mate 3 pv h5f7")!!
+        assertEquals(3, mating.scoreMate)
+        assertNull(mating.scoreCp)
+
+        val mated = UciInfoParser.parse("info depth 20 score mate -2 pv e8e7")!!
+        assertEquals(-2, mated.scoreMate)
+    }
+
+    @Test
+    fun `flags bound scores`() {
+        val lower = UciInfoParser.parse("info depth 10 score cp 50 lowerbound nodes 100")!!
+        assertTrue(lower.isBound)
+        val upper = UciInfoParser.parse("info depth 10 score cp -10 upperbound nodes 100")!!
+        assertTrue(upper.isBound)
+    }
+
+    @Test
+    fun `defaults multipv to 1 and reads explicit ranks`() {
+        assertEquals(1, UciInfoParser.parse("info depth 5 score cp 0 pv e2e4")!!.multipv)
+        assertEquals(
+            2,
+            UciInfoParser.parse("info depth 5 multipv 2 score cp -12 pv d2d4")!!.multipv
+        )
+    }
+
+    @Test
+    fun `ignores lines without a score`() {
+        assertNull(UciInfoParser.parse("info depth 5 currmove e2e4 currmovenumber 1"))
+        assertNull(UciInfoParser.parse("info string NNUE evaluation disabled"))
+        assertNull(UciInfoParser.parse("bestmove e2e4 ponder e7e5"))
+        assertNull(UciInfoParser.parse("readyok"))
+        assertNull(UciInfoParser.parse(""))
+    }
+
+    @Test
+    fun `survives malformed numeric fields`() {
+        // A garbled score value must not crash; without a usable score the line is dropped
+        assertNull(UciInfoParser.parse("info depth x score cp abc pv e2e4"))
+    }
+}

--- a/app/src/test/java/com/raichess/domain/model/MoveClassifierTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/MoveClassifierTest.kt
@@ -1,0 +1,55 @@
+package com.raichess.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MoveClassifierTest {
+
+    @Test
+    fun `centipawn loss is the eval drop and never negative`() {
+        assertEquals(150, MoveClassifier.centipawnLoss(evalBeforeCp = 100, evalAfterCp = -50))
+        assertEquals(0, MoveClassifier.centipawnLoss(evalBeforeCp = 10, evalAfterCp = 80))
+        assertEquals(0, MoveClassifier.centipawnLoss(evalBeforeCp = 25, evalAfterCp = 25))
+    }
+
+    @Test
+    fun `classification thresholds match the technical plan`() {
+        // Good: within 0.3 pawns of best
+        assertEquals(MoveClassification.GOOD, MoveClassifier.classify(0, playedEngineBest = false))
+        assertEquals(MoveClassification.GOOD, MoveClassifier.classify(29, playedEngineBest = false))
+        // Inaccuracy: 0.3-1.0 pawn loss
+        assertEquals(MoveClassification.INACCURACY, MoveClassifier.classify(30, playedEngineBest = false))
+        assertEquals(MoveClassification.INACCURACY, MoveClassifier.classify(99, playedEngineBest = false))
+        // Mistake: 1.0-3.0 pawn loss
+        assertEquals(MoveClassification.MISTAKE, MoveClassifier.classify(100, playedEngineBest = false))
+        assertEquals(MoveClassification.MISTAKE, MoveClassifier.classify(299, playedEngineBest = false))
+        // Blunder: 3.0+ pawn loss
+        assertEquals(MoveClassification.BLUNDER, MoveClassifier.classify(300, playedEngineBest = false))
+        assertEquals(MoveClassification.BLUNDER, MoveClassifier.classify(2000, playedEngineBest = false))
+    }
+
+    @Test
+    fun `playing the engine best move is BEST regardless of loss`() {
+        // In practice a best move has ~0 loss, but eval noise between
+        // searches must not demote the engine's own first choice
+        assertEquals(MoveClassification.BEST, MoveClassifier.classify(0, playedEngineBest = true))
+        assertEquals(MoveClassification.BEST, MoveClassifier.classify(45, playedEngineBest = true))
+    }
+
+    @Test
+    fun `accuracy is linear in acpl with a floor at zero`() {
+        assertEquals(100.0, MoveClassifier.accuracyFromAcpl(0.0), 1e-9)
+        assertEquals(75.0, MoveClassifier.accuracyFromAcpl(100.0), 1e-9)
+        assertEquals(50.0, MoveClassifier.accuracyFromAcpl(200.0), 1e-9)
+        assertEquals(0.0, MoveClassifier.accuracyFromAcpl(1_000_000.0), 1e-9)
+    }
+
+    @Test
+    fun `effectiveCp caps runaway and mate scores`() {
+        assertEquals(40, PositionAnalysis(scoreCp = 40, mateIn = null, bestMoveLan = "e2e4").effectiveCp())
+        assertEquals(1000, PositionAnalysis(scoreCp = 5200, mateIn = null, bestMoveLan = "e2e4").effectiveCp())
+        assertEquals(-1000, PositionAnalysis(scoreCp = -9999, mateIn = null, bestMoveLan = "e2e4").effectiveCp())
+        assertEquals(1000, PositionAnalysis(scoreCp = null, mateIn = 3, bestMoveLan = "h5f7").effectiveCp())
+        assertEquals(-1000, PositionAnalysis(scoreCp = null, mateIn = -2, bestMoveLan = "e8e7").effectiveCp())
+    }
+}

--- a/app/src/test/java/com/raichess/domain/model/PgnBuilderTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/PgnBuilderTest.kt
@@ -1,0 +1,62 @@
+package com.raichess.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PgnBuilderTest {
+
+    @Test
+    fun `builds headers and numbered movetext`() {
+        val pgn = PgnBuilder.build(
+            sanMoves = listOf("e4", "e5", "Nf3", "Nc6", "Bb5"),
+            result = GameResult.WIN,
+            playerColor = PlayerColor.WHITE,
+            opponentElo = 1500,
+            datePlayed = 0L
+        )
+        assertTrue(pgn.contains("[Event \"RaiChess\"]"))
+        assertTrue(pgn.contains("[White \"Player\"]"))
+        assertTrue(pgn.contains("[Black \"RaiChess AI (1500)\"]"))
+        assertTrue(pgn.contains("[Result \"1-0\"]"))
+        assertTrue(pgn.contains(Regex("\\[Date \"\\d{4}\\.\\d{2}\\.\\d{2}\"\\]")))
+        assertTrue(pgn.endsWith("1. e4 e5 2. Nf3 Nc6 3. Bb5 1-0"))
+    }
+
+    @Test
+    fun `player as black swaps the name tags and result`() {
+        val pgn = PgnBuilder.build(
+            sanMoves = listOf("e4", "e5"),
+            result = GameResult.LOSS,
+            playerColor = PlayerColor.BLACK,
+            opponentElo = 2000,
+            datePlayed = 0L
+        )
+        assertTrue(pgn.contains("[White \"RaiChess AI (2000)\"]"))
+        assertTrue(pgn.contains("[Black \"Player\"]"))
+        assertTrue(pgn.contains("[Result \"1-0\"]"))
+        assertTrue(pgn.endsWith("1. e4 e5 1-0"))
+    }
+
+    @Test
+    fun `draw uses the draw tag`() {
+        val pgn = PgnBuilder.build(
+            sanMoves = listOf("e4"),
+            result = GameResult.DRAW,
+            playerColor = PlayerColor.WHITE,
+            opponentElo = 1200,
+            datePlayed = 0L
+        )
+        assertTrue(pgn.endsWith("1. e4 1/2-1/2"))
+    }
+
+    @Test
+    fun `toPgnResult round-trips with fromPgnResult`() {
+        for (result in GameResult.values()) {
+            for (color in PlayerColor.values()) {
+                val tag = result.toPgnResult(color)
+                assertEquals(result, GameResult.fromPgnResult(tag, color))
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/raichess/domain/usecase/GameAnalyzerTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/GameAnalyzerTest.kt
@@ -1,0 +1,130 @@
+package com.raichess.domain.usecase
+
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.move.Move
+import com.raichess.data.engine.ChessEngine
+import com.raichess.domain.model.MoveClassification
+import com.raichess.domain.model.PositionAnalysis
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Drives GameAnalyzer with a scripted engine so the eval-perspective and
+ * centipawn-loss math is checked against hand-computed expectations.
+ */
+class GameAnalyzerTest {
+
+    /** Returns the queued analyses in order; fails the test if over-consumed. */
+    private class ScriptedEngine(analyses: List<PositionAnalysis?>) : ChessEngine {
+        private val queue = analyses.toMutableList()
+        var calls = 0
+            private set
+
+        override fun selectMove(board: Board): Move? = error("not an opponent")
+        override val activeEngineLabel = "Scripted"
+        override fun analyze(board: Board, moveTimeMs: Long): PositionAnalysis? {
+            calls++
+            check(queue.isNotEmpty()) { "engine asked for more analyses than scripted" }
+            return queue.removeAt(0)
+        }
+    }
+
+    private fun cp(score: Int, best: String) =
+        PositionAnalysis(scoreCp = score, mateIn = null, bestMoveLan = best, depth = 12)
+
+    @Test
+    fun `best move by the player is graded BEST with zero loss`() {
+        // 1. e4 e5 — player is White. Evals are side-to-move perspective:
+        // start +20 (White), after e4 -30 for Black (White +30), then +10.
+        val engine = ScriptedEngine(
+            listOf(
+                cp(20, "e2e4"),   // before White's move
+                cp(-30, "e7e5"),  // before Black's move
+                cp(10, "g1f3")    // final position (game not over)
+            )
+        )
+        val report = GameAnalyzer(engine).analyze(listOf("e2e4", "e7e5"), playerIsWhite = true)!!
+
+        assertEquals(3, engine.calls)
+        assertEquals(2, report.moves.size)
+
+        val white = report.moves[0]
+        assertTrue(white.isPlayerMove)
+        assertEquals(0, white.centipawnLoss)
+        assertEquals(MoveClassification.BEST, white.classification)
+        assertEquals(20, white.evaluationCp) // White to move: already White's view
+
+        val black = report.moves[1]
+        assertEquals(false, black.isPlayerMove)
+        assertNull(black.centipawnLoss)
+        assertNull(black.classification)
+        assertEquals(30, black.evaluationCp) // Black to move -30 → White's view +30
+
+        assertEquals(0.0, report.acpl, 1e-9)
+        assertEquals(100.0, report.accuracy, 1e-9)
+    }
+
+    @Test
+    fun `losing eval swings are graded and terminal mate needs no engine call`() {
+        // Fool's mate: 1. f3 e5 2. g4?? Qh4# — player is White.
+        val engine = ScriptedEngine(
+            listOf(
+                cp(20, "e2e4"),    // before f3: +20, best e4 → f3 loses 70
+                cp(50, "e7e5"),    // before e5 (Black's move, ungraded)
+                cp(-80, "d2d4"),   // before g4: -80 for White
+                PositionAnalysis(scoreCp = null, mateIn = 1, bestMoveLan = "d8h4", depth = 15)
+                // no 5th analysis: the final position is checkmate
+            )
+        )
+        val report = GameAnalyzer(engine)
+            .analyze(listOf("f2f3", "e7e5", "g2g4", "d8h4"), playerIsWhite = true)!!
+
+        assertEquals(4, engine.calls)
+
+        val f3 = report.moves[0]
+        // before +20, after: Black's +50 → White -50; loss 70 → inaccuracy
+        assertEquals(70, f3.centipawnLoss)
+        assertEquals(MoveClassification.INACCURACY, f3.classification)
+
+        val g4 = report.moves[2]
+        // before -80; after: mate-in-1 for Black (+1000 capped) → White -1000
+        assertEquals(920, g4.centipawnLoss)
+        assertEquals(MoveClassification.BLUNDER, g4.classification)
+
+        val qh4 = report.moves[3]
+        assertEquals(false, qh4.isPlayerMove)
+        // Black to move with mate in 1: +1000 for Black → -1000 White's view
+        assertEquals(-1000, qh4.evaluationCp)
+
+        assertEquals((70 + 920) / 2.0, report.acpl, 1e-9)
+    }
+
+    @Test
+    fun `no player moves yields neutral accuracy`() {
+        // Player is Black and resigned after White's first move
+        val engine = ScriptedEngine(listOf(cp(20, "e2e4"), cp(-20, "e7e5")))
+        val report = GameAnalyzer(engine).analyze(listOf("e2e4"), playerIsWhite = false)!!
+        assertNull(report.moves[0].centipawnLoss)
+        assertEquals(50.0, report.accuracy, 1e-9)
+    }
+
+    @Test
+    fun `aborts when the engine cannot analyze a position`() {
+        val engine = ScriptedEngine(listOf(cp(20, "e2e4"), null))
+        assertNull(GameAnalyzer(engine).analyze(listOf("e2e4", "e7e5"), playerIsWhite = true))
+    }
+
+    @Test
+    fun `aborts on a move that is not legal`() {
+        val engine = ScriptedEngine(listOf(cp(20, "e2e4")))
+        assertNull(GameAnalyzer(engine).analyze(listOf("e2e5"), playerIsWhite = true))
+    }
+
+    @Test
+    fun `rejects an empty game`() {
+        val engine = ScriptedEngine(emptyList())
+        assertNull(GameAnalyzer(engine).analyze(emptyList(), playerIsWhite = true))
+    }
+}


### PR DESCRIPTION
Foundation for personalized hints and coaching (stored observations,
derived interpretation):

- Room database (games / positions / practice_positions): finished games
  are persisted as PGN + raw LAN plies, and every analyzed ply is stored
  as an immutable observation row (eval, best move, centipawn loss,
  classification) with analyzer version/depth so games can be re-analyzed
  deeper later. themes column reserved for the tagging phase.
- ChessEngine.analyze(): full-strength position analysis alongside
  selectMove(). StockfishWasmEngine parses UCI info lines (UciInfoParser)
  in a new analysis mode that skips skill limiting; RaiEngine provides a
  fixed-depth fallback analyzer so analysis works even without WASM.
- GameAnalyzer: replays a finished game, grades each player move
  (centipawn loss, BEST/GOOD/INACCURACY/MISTAKE/BLUNDER per the
  TECHNICAL_PLAN thresholds) and computes ACPL-based accuracy.
- AnalysisCoordinator: app-lifetime background pipeline — saves the game
  at game over, analyzes it, and drains PENDING games on next launch if
  the process died mid-run.
- PracticeRepository migrated from SharedPreferences to Room with a
  one-time legacy JSON import; list maintenance stays in the tested
  PracticePositionStore.

Unit tests: UCI info parsing, classification thresholds and accuracy
formula, PGN building, GameAnalyzer perspective/loss math against a
scripted engine, RaiEngine analyze honesty and mate reporting.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p