### PR TITLE
feat: Phase B of coaching roadmap — mistake theme tagging and weakness profile

### DIFF
--- a/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
+++ b/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
@@ -35,6 +35,9 @@ object AnalysisCoordinator {
     /** Max games one pending sweep re-analyzes (~15s of engine time each). */
     private const val MAX_GAMES_PER_SWEEP = 10
 
+    private const val PREFS_NAME = "raichess_analysis"
+    private const val KEY_REQUEUED_VERSION = "requeued_for_analyzer_version"
+
     // IO, not Default: analysis time is dominated by blocking waits on the
     // engine's output queue, and Default's small pool is what the live
     // game's own move search runs on — analysis must not starve it.
@@ -79,7 +82,16 @@ object AnalysisCoordinator {
             try {
                 // Analyzer semantics changed (e.g. themes in v2)? Re-analyze
                 // old games so the weakness profile isn't sparse for history.
-                repository.requeueOutdatedAnalyses()
+                // Once the requeue has run for the current version it never
+                // needs to run again (the UPDATE flips every outdated game
+                // in one statement), so remember that in prefs — the query
+                // scans the whole positions table and shouldn't be a
+                // forever-cost on every cold start.
+                val prefs = appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                if (prefs.getInt(KEY_REQUEUED_VERSION, 0) < GameAnalyzer.VERSION) {
+                    repository.requeueOutdatedAnalyses()
+                    prefs.edit().putInt(KEY_REQUEUED_VERSION, GameAnalyzer.VERSION).apply()
+                }
                 val pending = repository.pendingAnalysisGameIds()
                 if (pending.isEmpty()) return@launch
                 // Cap the per-launch batch: a long history re-queued by an

--- a/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
+++ b/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
@@ -74,6 +74,10 @@ object AnalysisCoordinator {
         scope.launch {
             val repository = GameRepository(appContext)
             try {
+                // Analyzer semantics changed (e.g. themes in v2)? Re-analyze
+                // old games so the weakness profile isn't sparse for history.
+                // Bounded (game count), serialized, and once per process.
+                repository.requeueOutdatedAnalyses()
                 val pending = repository.pendingAnalysisGameIds()
                 if (pending.isEmpty()) return@launch
                 withAnalysisEngine(appContext) { engine ->

--- a/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
+++ b/app/src/main/java/com/raichess/data/analysis/AnalysisCoordinator.kt
@@ -32,6 +32,9 @@ object AnalysisCoordinator {
 
     private const val TAG = "AnalysisCoordinator"
 
+    /** Max games one pending sweep re-analyzes (~15s of engine time each). */
+    private const val MAX_GAMES_PER_SWEEP = 10
+
     // IO, not Default: analysis time is dominated by blocking waits on the
     // engine's output queue, and Default's small pool is what the live
     // game's own move search runs on — analysis must not starve it.
@@ -76,12 +79,21 @@ object AnalysisCoordinator {
             try {
                 // Analyzer semantics changed (e.g. themes in v2)? Re-analyze
                 // old games so the weakness profile isn't sparse for history.
-                // Bounded (game count), serialized, and once per process.
                 repository.requeueOutdatedAnalyses()
                 val pending = repository.pendingAnalysisGameIds()
                 if (pending.isEmpty()) return@launch
+                // Cap the per-launch batch: a long history re-queued by an
+                // analyzer bump would otherwise mean hours of background
+                // engine time in one sweep. The remainder stays PENDING
+                // (old rows keep serving queries until replaced) and the
+                // next launch continues the drain. Fresh games are analyzed
+                // by saveAndAnalyze directly, never queued behind this.
+                val batch = pending.take(MAX_GAMES_PER_SWEEP)
+                if (pending.size > batch.size) {
+                    Log.i(TAG, "analysis backlog: ${pending.size} games, processing ${batch.size} this launch")
+                }
                 withAnalysisEngine(appContext) { engine ->
-                    pending.forEach { analyzeGameWith(engine, repository, it) }
+                    batch.forEach { analyzeGameWith(engine, repository, it) }
                 }
             } catch (e: Exception) {
                 Log.w(TAG, "pending-analysis sweep failed", e)

--- a/app/src/main/java/com/raichess/data/database/GameDao.kt
+++ b/app/src/main/java/com/raichess/data/database/GameDao.kt
@@ -60,7 +60,13 @@ interface GameDao {
      * Flip games analyzed by an older pipeline back to PENDING so the next
      * sweep re-analyzes them under the current [com.raichess.domain.usecase.GameAnalyzer.VERSION]
      * (e.g. v1 rows have no themes). recordAnalysis deletes the old rows
-     * before inserting, so re-analysis is idempotent.
+     * before inserting, so re-analysis is idempotent. The old accuracy is
+     * deliberately kept until re-analysis lands (a valid prior grade beats
+     * a blank); readers of accuracy should gate on analysisState = DONE.
+     *
+     * The subquery scans positions (no analyzerVersion index), so callers
+     * run this once per version bump, not per launch — see
+     * AnalysisCoordinator's prefs marker.
      */
     @Query(
         "UPDATE games SET analysisState = '${AnalysisState.PENDING}' " +

--- a/app/src/main/java/com/raichess/data/database/GameDao.kt
+++ b/app/src/main/java/com/raichess/data/database/GameDao.kt
@@ -5,6 +5,14 @@ import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Transaction
 
+/** Projection row for [GameDao.recentPlayerMistakes]. */
+data class MistakeRow(
+    val gameId: Long,
+    val datePlayed: Long,
+    val themes: String,
+    val centipawnLoss: Int
+)
+
 @Dao
 interface GameDao {
 
@@ -34,6 +42,19 @@ interface GameDao {
 
     @Query("UPDATE games SET accuracy = :accuracy, analysisState = :state WHERE id = :gameId")
     suspend fun setAnalysisResult(gameId: Long, accuracy: Double?, state: String)
+
+    /**
+     * The player's graded mistakes across analyzed games, newest game
+     * first — the observation stream the weakness profile is derived from.
+     */
+    @Query(
+        "SELECT p.gameId AS gameId, g.datePlayed AS datePlayed, " +
+            "p.themes AS themes, p.centipawnLoss AS centipawnLoss " +
+            "FROM positions p JOIN games g ON p.gameId = g.id " +
+            "WHERE p.isPlayerMove = 1 AND p.centipawnLoss >= :minLossCp " +
+            "ORDER BY g.datePlayed DESC, p.ply ASC LIMIT :limit"
+    )
+    suspend fun recentPlayerMistakes(minLossCp: Int, limit: Int): List<MistakeRow>
 
     /** Clear any half-written rows from a previous attempt, then store the new ones. */
     @Query("DELETE FROM positions WHERE gameId = :gameId")

--- a/app/src/main/java/com/raichess/data/database/GameDao.kt
+++ b/app/src/main/java/com/raichess/data/database/GameDao.kt
@@ -56,6 +56,19 @@ interface GameDao {
     )
     suspend fun recentPlayerMistakes(minLossCp: Int, limit: Int): List<MistakeRow>
 
+    /**
+     * Flip games analyzed by an older pipeline back to PENDING so the next
+     * sweep re-analyzes them under the current [com.raichess.domain.usecase.GameAnalyzer.VERSION]
+     * (e.g. v1 rows have no themes). recordAnalysis deletes the old rows
+     * before inserting, so re-analysis is idempotent.
+     */
+    @Query(
+        "UPDATE games SET analysisState = '${AnalysisState.PENDING}' " +
+            "WHERE analysisState = '${AnalysisState.DONE}' AND id IN " +
+            "(SELECT DISTINCT gameId FROM positions WHERE analyzerVersion < :version)"
+    )
+    suspend fun requeueOutdatedAnalyses(version: Int)
+
     /** Clear any half-written rows from a previous attempt, then store the new ones. */
     @Query("DELETE FROM positions WHERE gameId = :gameId")
     suspend fun deletePositionsForGame(gameId: Long)

--- a/app/src/main/java/com/raichess/data/database/GameDao.kt
+++ b/app/src/main/java/com/raichess/data/database/GameDao.kt
@@ -8,7 +8,6 @@ import androidx.room.Transaction
 /** Projection row for [GameDao.recentPlayerMistakes]. */
 data class MistakeRow(
     val gameId: Long,
-    val datePlayed: Long,
     val themes: String,
     val centipawnLoss: Int
 )
@@ -48,8 +47,7 @@ interface GameDao {
      * first — the observation stream the weakness profile is derived from.
      */
     @Query(
-        "SELECT p.gameId AS gameId, g.datePlayed AS datePlayed, " +
-            "p.themes AS themes, p.centipawnLoss AS centipawnLoss " +
+        "SELECT p.gameId AS gameId, p.themes AS themes, p.centipawnLoss AS centipawnLoss " +
             "FROM positions p JOIN games g ON p.gameId = g.id " +
             "WHERE p.isPlayerMove = 1 AND p.centipawnLoss >= :minLossCp " +
             "ORDER BY g.datePlayed DESC, p.ply ASC LIMIT :limit"

--- a/app/src/main/java/com/raichess/data/repository/GameRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/GameRepository.kt
@@ -6,7 +6,12 @@ import com.raichess.data.database.GameEntity
 import com.raichess.data.database.PositionEntity
 import com.raichess.data.database.RaiChessDatabase
 import com.raichess.domain.model.CompletedGame
+import com.raichess.domain.model.MoveClassifier
+import com.raichess.domain.model.ThemeTag
 import com.raichess.domain.usecase.GameAnalyzer
+import com.raichess.domain.usecase.MistakeObservation
+import com.raichess.domain.usecase.ThemeStat
+import com.raichess.domain.usecase.WeaknessProfiler
 
 /**
  * Room-backed game history: finished games plus their per-move analysis.
@@ -59,11 +64,34 @@ class GameRepository(context: Context) {
                 isPlayerMove = move.isPlayerMove,
                 centipawnLoss = move.centipawnLoss,
                 classification = move.classification?.name,
+                themes = ThemeTag.toCsv(move.themes),
                 analysisDepth = move.depth,
                 analyzerVersion = GameAnalyzer.VERSION
             )
         }
         dao.recordAnalysis(gameId, rows, report.accuracy)
+    }
+
+    /**
+     * The player's current weakness profile, derived on demand from stored
+     * mistake observations (never persisted — see WeaknessProfiler). Games
+     * are ranked newest-first for the recency decay; a game with no graded
+     * mistakes doesn't advance the clock, which slightly *slows* decay for
+     * clean stretches — acceptable, since a clean stretch also adds no new
+     * observations to outweigh.
+     */
+    suspend fun weaknessProfile(maxObservations: Int = 500): List<ThemeStat> {
+        val rows = dao.recentPlayerMistakes(MoveClassifier.MISTAKE_THRESHOLD_CP, maxObservations)
+        val gameRank = rows.map { it.gameId }.distinct()
+            .withIndex().associate { (rank, id) -> id to rank }
+        val observations = rows.map { row ->
+            MistakeObservation(
+                gamesAgo = gameRank.getValue(row.gameId),
+                themes = ThemeTag.fromCsv(row.themes),
+                lossCp = row.centipawnLoss
+            )
+        }
+        return WeaknessProfiler.build(observations)
     }
 
     suspend fun markAnalysisFailed(gameId: Long) {

--- a/app/src/main/java/com/raichess/data/repository/GameRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/GameRepository.kt
@@ -10,7 +10,7 @@ import com.raichess.domain.model.MoveClassifier
 import com.raichess.domain.model.ThemeTag
 import com.raichess.domain.usecase.GameAnalyzer
 import com.raichess.domain.usecase.MistakeObservation
-import com.raichess.domain.usecase.ThemeStat
+import com.raichess.domain.usecase.WeaknessProfile
 import com.raichess.domain.usecase.WeaknessProfiler
 
 /**
@@ -52,6 +52,9 @@ class GameRepository(context: Context) {
     /** Games saved but not yet (successfully) analyzed, oldest first. */
     suspend fun pendingAnalysisGameIds(): List<Long> = dao.pendingAnalysisGameIds()
 
+    /** Re-queue games analyzed by an older pipeline version for re-analysis. */
+    suspend fun requeueOutdatedAnalyses() = dao.requeueOutdatedAnalyses(GameAnalyzer.VERSION)
+
     suspend fun recordAnalysis(gameId: Long, report: GameAnalyzer.GameReport) {
         val rows = report.moves.map { move ->
             PositionEntity(
@@ -80,7 +83,7 @@ class GameRepository(context: Context) {
      * clean stretches — acceptable, since a clean stretch also adds no new
      * observations to outweigh.
      */
-    suspend fun weaknessProfile(maxObservations: Int = 500): List<ThemeStat> {
+    suspend fun weaknessProfile(maxObservations: Int = 500): WeaknessProfile {
         val rows = dao.recentPlayerMistakes(MoveClassifier.MISTAKE_THRESHOLD_CP, maxObservations)
         val gameRank = rows.map { it.gameId }.distinct()
             .withIndex().associate { (rank, id) -> id to rank }

--- a/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
@@ -2,6 +2,7 @@ package com.raichess.data.repository
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.reflect.TypeToken
@@ -9,7 +10,6 @@ import com.raichess.data.database.RaiChessDatabase
 import com.raichess.data.database.toDomain
 import com.raichess.data.database.toEntity
 import com.raichess.domain.model.PracticeCategory
-import android.util.Log
 import com.raichess.domain.model.PracticePosition
 import com.raichess.domain.model.PracticePositionStore
 import kotlinx.coroutines.CoroutineScope
@@ -58,6 +58,8 @@ class PracticeRepository(context: Context) {
         writeScope.launch {
             try {
                 addMistakePosition(fen, sourceMoveNumber, sourceGameId)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e // never swallow cancellation
             } catch (e: Exception) {
                 Log.w(TAG, "failed to record mistake position", e)
             }

--- a/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
@@ -37,8 +37,6 @@ class PracticeRepository(context: Context) {
     private val dao = RaiChessDatabase.get(appContext).practiceDao()
     private val prefs: SharedPreferences =
         appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    // Serializes read-merge-write updates from concurrent callers
-    private val writeMutex = Mutex()
 
     suspend fun getPositions(): List<PracticePosition> {
         importLegacyIfNeeded()
@@ -135,5 +133,10 @@ class PracticeRepository(context: Context) {
         // Process-lifetime so recordMistakePosition writes survive the
         // teardown of whichever screen triggered them.
         private val writeScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+        // Companion-scoped (not per-instance) so read-merge-write updates
+        // stay serialized even if a second screen ever constructs its own
+        // PracticeRepository — all instances share the singleton database.
+        private val writeMutex = Mutex()
     }
 }

--- a/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
@@ -12,6 +12,7 @@ import com.raichess.data.database.toEntity
 import com.raichess.domain.model.PracticeCategory
 import com.raichess.domain.model.PracticePosition
 import com.raichess.domain.model.PracticePositionStore
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -58,7 +59,7 @@ class PracticeRepository(context: Context) {
         writeScope.launch {
             try {
                 addMistakePosition(fen, sourceMoveNumber, sourceGameId)
-            } catch (e: kotlinx.coroutines.CancellationException) {
+            } catch (e: CancellationException) {
                 throw e // never swallow cancellation
             } catch (e: Exception) {
                 Log.w(TAG, "failed to record mistake position", e)

--- a/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/PracticeRepository.kt
@@ -9,8 +9,13 @@ import com.raichess.data.database.RaiChessDatabase
 import com.raichess.data.database.toDomain
 import com.raichess.data.database.toEntity
 import com.raichess.domain.model.PracticeCategory
+import android.util.Log
 import com.raichess.domain.model.PracticePosition
 import com.raichess.domain.model.PracticePositionStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.UUID
@@ -37,6 +42,26 @@ class PracticeRepository(context: Context) {
     suspend fun getPositions(): List<PracticePosition> {
         importLegacyIfNeeded()
         return dao.getAll().map { it.toDomain() }
+    }
+
+    /**
+     * Fire-and-forget variant of [addMistakePosition] for in-game callers:
+     * runs on a repository-owned, process-lifetime scope so tearing down
+     * the calling screen right after an undo can't cancel the write and
+     * silently drop the observation (a viewModelScope launch would).
+     */
+    fun recordMistakePosition(
+        fen: String,
+        sourceMoveNumber: Int,
+        sourceGameId: Long? = null
+    ) {
+        writeScope.launch {
+            try {
+                addMistakePosition(fen, sourceMoveNumber, sourceGameId)
+            } catch (e: Exception) {
+                Log.w(TAG, "failed to record mistake position", e)
+            }
+        }
     }
 
     /**
@@ -99,8 +124,13 @@ class PracticeRepository(context: Context) {
     }
 
     companion object {
+        private const val TAG = "PracticeRepository"
         private const val PREFS_NAME = "raichess_practice"
         private const val KEY_POSITIONS = "positions"
         private const val KEY_MIGRATED = "migrated_to_room"
+
+        // Process-lifetime so recordMistakePosition writes survive the
+        // teardown of whichever screen triggered them.
+        private val writeScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     }
 }

--- a/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
+++ b/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
@@ -31,7 +31,9 @@ object MoveClassifier {
     const val EVAL_CAP_CP = 1000
 
     private const val INACCURACY_THRESHOLD_CP = 30
-    private const val MISTAKE_THRESHOLD_CP = 100
+
+    /** Public: ThemeTagger and the weakness profile gate on mistake-or-worse. */
+    const val MISTAKE_THRESHOLD_CP = 100
     private const val BLUNDER_THRESHOLD_CP = 300
 
     /**

--- a/app/src/main/java/com/raichess/domain/model/ThemeTag.kt
+++ b/app/src/main/java/com/raichess/domain/model/ThemeTag.kt
@@ -1,0 +1,38 @@
+package com.raichess.domain.model
+
+/**
+ * Machine-detectable labels for *why* a graded move lost ground, plus the
+ * game phase it happened in. Stored per position row (CSV in the themes
+ * column) as immutable observations; the weakness profile aggregates them
+ * with recency decay, so interpretation can always be recomputed as the
+ * taxonomy grows — add new tags, re-analyze, never migrate.
+ */
+enum class ThemeTag(val id: String) {
+    /** The moved piece landed where it can be won (attacked and under-defended). */
+    HANGING_PIECE("hanging_piece"),
+    /** The move let the opponent's best reply win significant material elsewhere. */
+    ALLOWED_TACTIC("allowed_tactic"),
+    /** The move gave the opponent a forced mate. */
+    ALLOWED_MATE("allowed_mate"),
+    /** A forced mate was available and not played. */
+    MISSED_MATE("missed_mate"),
+    /** The engine's best move won significant material and wasn't played. */
+    MISSED_CAPTURE("missed_capture"),
+    /** Game phase at the moment of the mistake. */
+    OPENING("opening"),
+    MIDDLEGAME("middlegame"),
+    ENDGAME("endgame");
+
+    companion object {
+        private val byId = entries.associateBy { it.id }
+
+        fun toCsv(tags: Set<ThemeTag>): String =
+            tags.sortedBy { it.ordinal }.joinToString(",") { it.id }
+
+        /** Unknown ids are skipped, so old rows survive future taxonomy changes. */
+        fun fromCsv(csv: String): Set<ThemeTag> =
+            csv.split(',')
+                .mapNotNull { byId[it.trim()] }
+                .toSet()
+    }
+}

--- a/app/src/main/java/com/raichess/domain/model/ThemeTag.kt
+++ b/app/src/main/java/com/raichess/domain/model/ThemeTag.kt
@@ -7,7 +7,7 @@ package com.raichess.domain.model
  * with recency decay, so interpretation can always be recomputed as the
  * taxonomy grows — add new tags, re-analyze, never migrate.
  */
-enum class ThemeTag(val id: String) {
+enum class ThemeTag(val id: String, val isPhase: Boolean = false) {
     /** The moved piece landed where it can be won (attacked and under-defended). */
     HANGING_PIECE("hanging_piece"),
     /** The move let the opponent's best reply win significant material elsewhere. */
@@ -18,10 +18,15 @@ enum class ThemeTag(val id: String) {
     MISSED_MATE("missed_mate"),
     /** The engine's best move won significant material and wasn't played. */
     MISSED_CAPTURE("missed_capture"),
-    /** Game phase at the moment of the mistake. */
-    OPENING("opening"),
-    MIDDLEGAME("middlegame"),
-    ENDGAME("endgame");
+    /**
+     * Game phase at the moment of the mistake. Phase tags attach to *every*
+     * graded mistake (exactly one per observation), unlike the substantive
+     * tags above, which only fire when a detector recognizes the pattern —
+     * so the profile ranks the two kinds separately (see WeaknessProfiler).
+     */
+    OPENING("opening", isPhase = true),
+    MIDDLEGAME("middlegame", isPhase = true),
+    ENDGAME("endgame", isPhase = true);
 
     companion object {
         private val byId = entries.associateBy { it.id }

--- a/app/src/main/java/com/raichess/domain/usecase/GameAnalyzer.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/GameAnalyzer.kt
@@ -8,6 +8,7 @@ import com.raichess.data.engine.ChessEngine
 import com.raichess.domain.model.MoveClassification
 import com.raichess.domain.model.MoveClassifier
 import com.raichess.domain.model.PositionAnalysis
+import com.raichess.domain.model.ThemeTag
 
 /**
  * Post-game analysis (TECHNICAL_PLAN.md §B): replays a finished game,
@@ -39,6 +40,8 @@ class GameAnalyzer(
         /** Player moves only; null for the AI's plies. */
         val centipawnLoss: Int?,
         val classification: MoveClassification?,
+        /** Mistake themes (player moves at mistake-or-worse loss only). */
+        val themes: Set<ThemeTag> = emptySet(),
         val depth: Int
     )
 
@@ -95,6 +98,18 @@ class GameAnalyzer(
 
             val isPlayerMove = step.whiteToMove == playerIsWhite
             val playedBest = step.moveLan.lowercase() == step.analysis.bestMoveLan?.lowercase()
+            val themes = if (isPlayerMove) {
+                ThemeTagger.tag(
+                    fenBefore = step.fen,
+                    ply = i,
+                    moveLan = step.moveLan,
+                    analysis = step.analysis,
+                    nextAnalysis = steps.getOrNull(i + 1)?.analysis,
+                    lossCp = loss
+                )
+            } else {
+                emptySet()
+            }
 
             MoveReport(
                 ply = i,
@@ -106,6 +121,7 @@ class GameAnalyzer(
                 bestMoveLan = step.analysis.bestMoveLan,
                 centipawnLoss = if (isPlayerMove) loss else null,
                 classification = if (isPlayerMove) MoveClassifier.classify(loss, playedBest) else null,
+                themes = themes,
                 depth = step.analysis.depth
             )
         }
@@ -125,8 +141,9 @@ class GameAnalyzer(
         /**
          * Bump when the analysis semantics change (thresholds, eval
          * conventions, tagging) so stored rows can be found and re-analyzed.
+         * v2: theme tagging (Phase B).
          */
-        const val VERSION = 1
+        const val VERSION = 2
 
         /** Per-position budget: deep enough to grade honestly, ~15s for a 60-ply game. */
         const val DEFAULT_MOVE_TIME_MS = 250L

--- a/app/src/main/java/com/raichess/domain/usecase/ThemeTagger.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/ThemeTagger.kt
@@ -1,0 +1,146 @@
+package com.raichess.domain.usecase
+
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.Piece
+import com.github.bhlangonijr.chesslib.PieceType
+import com.github.bhlangonijr.chesslib.Side
+import com.github.bhlangonijr.chesslib.Square
+import com.raichess.domain.model.MoveClassifier
+import com.raichess.domain.model.PositionAnalysis
+import com.raichess.domain.model.ThemeTag
+import kotlin.math.min
+
+/**
+ * Rule-based mistake tagging (Phase B of the coaching roadmap): given a
+ * graded player move, attach [ThemeTag]s explaining what kind of mistake it
+ * was. Everything is detectable from board geometry plus the evals already
+ * produced by GameAnalyzer — no extra engine calls.
+ *
+ * Deliberately conservative: tags are only attached to mistake-or-worse
+ * moves (loss >= [MoveClassifier.MISTAKE_THRESHOLD_CP]), and each detector
+ * prefers missing a tag over inventing one, because the weakness profile
+ * amplifies whatever is stored here.
+ */
+object ThemeTagger {
+
+    /** Material worth calling a "significant" win/loss when tagging. */
+    private const val SIGNIFICANT_MATERIAL_CP = 300
+
+    /** Plies before which a mistake counts as an opening mistake. */
+    private const val OPENING_PLY_LIMIT = 20
+
+    /** Non-pawn, non-king piece count at or below which it's an endgame. */
+    private const val ENDGAME_PIECE_LIMIT = 6
+
+    /**
+     * Tag one played move.
+     *
+     * @param fenBefore position before the move
+     * @param ply 0-based ply index of the move
+     * @param moveLan the move actually played
+     * @param analysis engine verdict on [fenBefore]
+     * @param nextAnalysis engine verdict on the position after the move
+     *   (side to move = opponent), or null when the move ended the game
+     * @param lossCp centipawn loss already computed for the move
+     */
+    fun tag(
+        fenBefore: String,
+        ply: Int,
+        moveLan: String,
+        analysis: PositionAnalysis,
+        nextAnalysis: PositionAnalysis?,
+        lossCp: Int
+    ): Set<ThemeTag> {
+        if (lossCp < MoveClassifier.MISTAKE_THRESHOLD_CP) return emptySet()
+
+        val board = Board().apply { loadFromFen(fenBefore) }
+        val played = GameAnalyzer.lanToLegalMove(board, moveLan) ?: return emptySet()
+        val playerSide = board.sideToMove
+        val opponentSide = if (playerSide == Side.WHITE) Side.BLACK else Side.WHITE
+
+        val tags = mutableSetOf(phaseOf(board, ply))
+
+        // What was available and not taken (evaluated on the pre-move board)
+        val bestLan = analysis.bestMoveLan
+        val playedBest = bestLan != null && bestLan == moveLan.lowercase()
+        if (!playedBest && bestLan != null) {
+            if ((analysis.mateIn ?: 0) > 0) tags.add(ThemeTag.MISSED_MATE)
+            val best = GameAnalyzer.lanToLegalMove(board, bestLan)
+            if (best != null &&
+                pieceValue(board.getPiece(best.to), opponentSide) >= SIGNIFICANT_MATERIAL_CP
+            ) {
+                tags.add(ThemeTag.MISSED_CAPTURE)
+            }
+        }
+
+        // What the move gave away (evaluated on the post-move board)
+        board.doMove(played)
+
+        if ((nextAnalysis?.mateIn ?: 0) > 0) tags.add(ThemeTag.ALLOWED_MATE)
+
+        val movedPieceValue = pieceValue(board.getPiece(played.to), playerSide)
+        val attackers = board.squareAttackedBy(played.to, opponentSide)
+        val hanging = movedPieceValue > 0 && attackers != 0L && (
+            board.squareAttackedBy(played.to, playerSide) == 0L ||
+                minPieceValueOn(board, attackers) < movedPieceValue
+            )
+        if (hanging) tags.add(ThemeTag.HANGING_PIECE)
+
+        val replyLan = nextAnalysis?.bestMoveLan
+        if (replyLan != null) {
+            val reply = GameAnalyzer.lanToLegalMove(board, replyLan)
+            // A winning reply against the moved piece itself is the
+            // HANGING_PIECE case; ALLOWED_TACTIC is for damage elsewhere.
+            if (reply != null && reply.to != played.to &&
+                pieceValue(board.getPiece(reply.to), playerSide) >= SIGNIFICANT_MATERIAL_CP
+            ) {
+                tags.add(ThemeTag.ALLOWED_TACTIC)
+            }
+        }
+
+        return tags
+    }
+
+    /** Endgame wins over ply count: a queen trade on move 8 is still an endgame. */
+    private fun phaseOf(board: Board, ply: Int): ThemeTag {
+        var pieces = 0
+        for (index in 0 until 64) {
+            val piece = board.getPiece(Square.squareAt(index))
+            if (piece == Piece.NONE) continue
+            val type = piece.pieceType ?: continue
+            if (type != PieceType.PAWN && type != PieceType.KING) pieces++
+        }
+        return when {
+            pieces <= ENDGAME_PIECE_LIMIT -> ThemeTag.ENDGAME
+            ply < OPENING_PLY_LIMIT -> ThemeTag.OPENING
+            else -> ThemeTag.MIDDLEGAME
+        }
+    }
+
+    /** Value of [piece] when it belongs to [side]; 0 for NONE or the other side. */
+    private fun pieceValue(piece: Piece, side: Side): Int {
+        if (piece == Piece.NONE || piece.pieceSide != side) return 0
+        return when (piece.pieceType) {
+            PieceType.PAWN -> 100
+            PieceType.KNIGHT -> 320
+            PieceType.BISHOP -> 330
+            PieceType.ROOK -> 500
+            PieceType.QUEEN -> 900
+            PieceType.KING -> KING_VALUE
+            else -> 0
+        }
+    }
+
+    private fun minPieceValueOn(board: Board, squaresBitboard: Long): Int {
+        var minValue = Int.MAX_VALUE
+        for (index in 0 until 64) {
+            if ((squaresBitboard ushr index) and 1L == 0L) continue
+            val piece = board.getPiece(Square.squareAt(index))
+            val side = piece.pieceSide ?: continue
+            minValue = min(minValue, pieceValue(piece, side))
+        }
+        return minValue
+    }
+
+    private const val KING_VALUE = 20_000
+}

--- a/app/src/main/java/com/raichess/domain/usecase/ThemeTagger.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/ThemeTagger.kt
@@ -78,6 +78,12 @@ object ThemeTagger {
 
         if ((nextAnalysis?.mateIn ?: 0) > 0) tags.add(ThemeTag.ALLOWED_MATE)
 
+        // Single-ply exchange approximation, not a full SEE: hanging means
+        // attacked while undefended, or attacked by something cheaper (a
+        // defended knight attacked by a pawn is still lost material). Pinned
+        // "defenders" are counted as defending even though they couldn't
+        // legally recapture — a false *negative*, which is the direction
+        // this tagger prefers to err in.
         val movedPieceValue = pieceValue(board.getPiece(played.to), playerSide)
         val attackers = board.squareAttackedBy(played.to, opponentSide)
         val hanging = movedPieceValue > 0 && attackers != 0L && (

--- a/app/src/main/java/com/raichess/domain/usecase/ThemeTagger.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/ThemeTagger.kt
@@ -60,7 +60,10 @@ object ThemeTagger {
 
         val tags = mutableSetOf(phaseOf(board, ply))
 
-        // What was available and not taken (evaluated on the pre-move board)
+        // What was available and not taken (evaluated on the pre-move board).
+        // Capture detection reads the piece on the move's destination, so an
+        // en passant capture reads as capturing nothing — a known false
+        // negative, the direction this tagger prefers to err in.
         val bestLan = analysis.bestMoveLan
         val playedBest = bestLan != null && bestLan == moveLan.lowercase()
         if (!playedBest && bestLan != null) {

--- a/app/src/main/java/com/raichess/domain/usecase/WeaknessProfiler.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/WeaknessProfiler.kt
@@ -1,0 +1,67 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.ThemeTag
+import kotlin.math.pow
+
+/**
+ * One tagged mistake, positioned by how many games ago it happened
+ * (0 = the most recent game with mistakes).
+ */
+data class MistakeObservation(
+    val gamesAgo: Int,
+    val themes: Set<ThemeTag>,
+    val lossCp: Int
+)
+
+/** Aggregated standing of one theme in the player's current profile. */
+data class ThemeStat(
+    val theme: ThemeTag,
+    /** Recency-weighted frequency — the ranking key. */
+    val score: Double,
+    /** Raw occurrence count, unweighted (for display: "5 times in your last N games"). */
+    val occurrences: Int,
+    /** Average severity of the mistakes carrying this tag, in centipawns. */
+    val avgLossCp: Double
+)
+
+/**
+ * Derives the player's weakness profile from stored mistake observations
+ * (Phase B of the coaching roadmap). The core design rule: observations are
+ * immutable, the profile is recomputed — so a player who stops hanging
+ * pieces sees that weakness *decay out* rather than follow them forever.
+ *
+ * Each observation is weighted 0.5^(gamesAgo / [HALF_LIFE_GAMES]): a
+ * mistake twenty games ago counts half as much as one from the latest game,
+ * forty games ago a quarter, and so on. Pure math, no storage or Android.
+ */
+object WeaknessProfiler {
+
+    /** Games for an observation's weight to halve. */
+    const val HALF_LIFE_GAMES = 20.0
+
+    /** Themes ranked worst-first; themes never observed are absent. */
+    fun build(observations: List<MistakeObservation>): List<ThemeStat> {
+        data class Acc(var score: Double = 0.0, var count: Int = 0, var lossSum: Long = 0)
+
+        val byTheme = HashMap<ThemeTag, Acc>()
+        for (obs in observations) {
+            val weight = 0.5.pow(obs.gamesAgo / HALF_LIFE_GAMES)
+            for (theme in obs.themes) {
+                val acc = byTheme.getOrPut(theme) { Acc() }
+                acc.score += weight
+                acc.count++
+                acc.lossSum += obs.lossCp
+            }
+        }
+        return byTheme.entries
+            .map { (theme, acc) ->
+                ThemeStat(
+                    theme = theme,
+                    score = acc.score,
+                    occurrences = acc.count,
+                    avgLossCp = acc.lossSum.toDouble() / acc.count
+                )
+            }
+            .sortedWith(compareByDescending<ThemeStat> { it.score }.thenBy { it.theme.ordinal })
+    }
+}

--- a/app/src/main/java/com/raichess/domain/usecase/WeaknessProfiler.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/WeaknessProfiler.kt
@@ -25,6 +25,26 @@ data class ThemeStat(
 )
 
 /**
+ * The player's current profile, ranked worst-first within each list.
+ *
+ * [weaknesses] and [phases] are ranked separately because they aren't
+ * comparable: a phase tag attaches to every graded mistake, while the
+ * substantive detectors are deliberately conservative — mixed together,
+ * "middlegame" would top the list by construction and crowd out the
+ * actionable weakness a hint should target.
+ */
+data class WeaknessProfile(
+    /** Substantive mistake types (hanging pieces, missed mates, ...). */
+    val weaknesses: List<ThemeStat>,
+    /** Where in the game the mistakes happen. */
+    val phases: List<ThemeStat>
+) {
+    companion object {
+        val EMPTY = WeaknessProfile(emptyList(), emptyList())
+    }
+}
+
+/**
  * Derives the player's weakness profile from stored mistake observations
  * (Phase B of the coaching roadmap). The core design rule: observations are
  * immutable, the profile is recomputed — so a player who stops hanging
@@ -39,8 +59,8 @@ object WeaknessProfiler {
     /** Games for an observation's weight to halve. */
     const val HALF_LIFE_GAMES = 20.0
 
-    /** Themes ranked worst-first; themes never observed are absent. */
-    fun build(observations: List<MistakeObservation>): List<ThemeStat> {
+    /** Themes never observed are absent from both lists. */
+    fun build(observations: List<MistakeObservation>): WeaknessProfile {
         data class Acc(var score: Double = 0.0, var count: Int = 0, var lossSum: Long = 0)
 
         val byTheme = HashMap<ThemeTag, Acc>()
@@ -53,7 +73,7 @@ object WeaknessProfiler {
                 acc.lossSum += obs.lossCp
             }
         }
-        return byTheme.entries
+        val ranked = byTheme.entries
             .map { (theme, acc) ->
                 ThemeStat(
                     theme = theme,
@@ -63,5 +83,7 @@ object WeaknessProfiler {
                 )
             }
             .sortedWith(compareByDescending<ThemeStat> { it.score }.thenBy { it.theme.ordinal })
+        val (phases, weaknesses) = ranked.partition { it.theme.isPhase }
+        return WeaknessProfile(weaknesses = weaknesses, phases = phases)
     }
 }

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -221,14 +221,13 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
         gameUndoCount++
         repository.incrementLifetimeUndos()
-        // Snapshot now: the suspend write races further play on the live board
-        val preMistakeFen = board.fen
-        viewModelScope.launch {
-            practiceRepository.addMistakePosition(
-                fen = preMistakeFen, // the position as it stood before the mistake
-                sourceMoveNumber = remaining.size / 2 + 1
-            )
-        }
+        // Process-lifetime write, not viewModelScope: leaving the screen
+        // right after an undo must not cancel the write and drop the
+        // observation
+        practiceRepository.recordMistakePosition(
+            fen = board.fen, // the position as it stood before the mistake
+            sourceMoveNumber = remaining.size / 2 + 1
+        )
 
         _uiState.value = state.copy(
             squares = boardSnapshot(),

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -223,7 +223,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         repository.incrementLifetimeUndos()
         // Process-lifetime write, not viewModelScope: leaving the screen
         // right after an undo must not cancel the write and drop the
-        // observation
+        // observation. board.fen must stay an eagerly-evaluated argument —
+        // snapshotting it inside a deferred lambda would race further play
+        // on the live board.
         practiceRepository.recordMistakePosition(
             fen = board.fen, // the position as it stood before the mistake
             sourceMoveNumber = remaining.size / 2 + 1

--- a/app/src/test/java/com/raichess/domain/model/ThemeTagTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/ThemeTagTest.kt
@@ -1,0 +1,31 @@
+package com.raichess.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThemeTagTest {
+
+    @Test
+    fun `csv round-trips`() {
+        val tags = setOf(ThemeTag.HANGING_PIECE, ThemeTag.ENDGAME, ThemeTag.MISSED_MATE)
+        assertEquals(tags, ThemeTag.fromCsv(ThemeTag.toCsv(tags)))
+    }
+
+    @Test
+    fun `csv is stable and ordinal-ordered`() {
+        assertEquals(
+            "hanging_piece,missed_mate,endgame",
+            ThemeTag.toCsv(setOf(ThemeTag.ENDGAME, ThemeTag.MISSED_MATE, ThemeTag.HANGING_PIECE))
+        )
+    }
+
+    @Test
+    fun `unknown ids and blanks are skipped on read`() {
+        assertEquals(
+            setOf(ThemeTag.HANGING_PIECE),
+            ThemeTag.fromCsv("hanging_piece,super_future_tag, ,")
+        )
+        assertTrue(ThemeTag.fromCsv("").isEmpty())
+    }
+}

--- a/app/src/test/java/com/raichess/domain/usecase/ThemeTaggerTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/ThemeTaggerTest.kt
@@ -1,0 +1,123 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.PositionAnalysis
+import com.raichess.domain.model.ThemeTag
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThemeTaggerTest {
+
+    private fun cp(score: Int, best: String?) =
+        PositionAnalysis(scoreCp = score, mateIn = null, bestMoveLan = best, depth = 12)
+
+    private fun mate(moves: Int, best: String?) =
+        PositionAnalysis(scoreCp = null, mateIn = moves, bestMoveLan = best, depth = 12)
+
+    @Test
+    fun `below mistake threshold yields no tags`() {
+        val tags = ThemeTagger.tag(
+            fenBefore = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+            ply = 0,
+            moveLan = "e2e4",
+            analysis = cp(20, "e2e4"),
+            nextAnalysis = cp(-20, "e7e5"),
+            lossCp = 40
+        )
+        assertTrue(tags.isEmpty())
+    }
+
+    @Test
+    fun `queen moved onto a defended pawn's square is hanging`() {
+        // After 1.e4 e5 (and ...g6): Qd1-h5?? hangs the queen to the g6 pawn
+        val tags = ThemeTagger.tag(
+            fenBefore = "rnbqkbnr/pppp1p1p/6p1/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 3",
+            ply = 4,
+            moveLan = "d1h5",
+            analysis = cp(30, "g1f3"),
+            nextAnalysis = cp(850, "g6h5"),
+            lossCp = 800
+        )
+        assertTrue(ThemeTag.HANGING_PIECE in tags)
+        assertTrue(ThemeTag.OPENING in tags)
+    }
+
+    @Test
+    fun `not playing an available mate is missed mate`() {
+        // Back rank: Ra1-a8 is mate; White shuffles the rook instead
+        val tags = ThemeTagger.tag(
+            fenBefore = "6k1/5ppp/8/8/8/8/8/R5K1 w - - 0 40",
+            ply = 78,
+            moveLan = "a1a2",
+            analysis = mate(1, "a1a8"),
+            nextAnalysis = cp(-400, "g8f8"),
+            lossCp = 600
+        )
+        assertTrue(ThemeTag.MISSED_MATE in tags)
+        assertTrue(ThemeTag.ENDGAME in tags)
+    }
+
+    @Test
+    fun `not taking a free queen is missed capture`() {
+        // White Rd2 can take the d5 queen; plays a2a3 instead
+        val tags = ThemeTagger.tag(
+            fenBefore = "k7/8/8/3q4/8/8/P2R4/K7 w - - 0 30",
+            ply = 58,
+            moveLan = "a2a3",
+            analysis = cp(400, "d2d5"),
+            nextAnalysis = cp(300, "d5d2"),
+            lossCp = 700
+        )
+        assertTrue(ThemeTag.MISSED_CAPTURE in tags)
+    }
+
+    @Test
+    fun `move that gives the opponent a forced mate is allowed mate`() {
+        // Fool's mate: after 1.f3 e5, 2.g4?? allows Qh4#
+        val tags = ThemeTagger.tag(
+            fenBefore = "rnbqkbnr/pppp1ppp/8/4p3/8/5P2/PPPPP1PP/RNBQKBNR w KQkq - 0 2",
+            ply = 2,
+            moveLan = "g2g4",
+            analysis = cp(-80, "d2d4"),
+            nextAnalysis = mate(1, "d8h4"),
+            lossCp = 920
+        )
+        assertTrue(ThemeTag.ALLOWED_MATE in tags)
+        assertTrue(ThemeTag.OPENING in tags)
+    }
+
+    @Test
+    fun `reply winning material elsewhere is allowed tactic, not hanging`() {
+        // White pushes a pawn; the engine says Black's best reply Qh1xb1
+        // wins the rook. The damage lands away from the moved pawn's
+        // square, which is what makes it ALLOWED_TACTIC rather than
+        // HANGING_PIECE. (Whether the capture is ultimately sound is the
+        // engine's judgment — the tagger trusts the supplied analysis.)
+        val tags = ThemeTagger.tag(
+            fenBefore = "k7/8/8/8/8/8/P7/KR5q w - - 0 30",
+            ply = 58,
+            moveLan = "a2a3",
+            analysis = cp(-200, "b1b8"),
+            nextAnalysis = cp(450, "h8b8"),
+            lossCp = 300
+        )
+        assertTrue(ThemeTag.ALLOWED_TACTIC in tags)
+        assertFalse(ThemeTag.HANGING_PIECE in tags)
+    }
+
+    @Test
+    fun `phase tags follow piece count then ply`() {
+        // Full board late in the game: middlegame
+        val middlegame = ThemeTagger.tag(
+            fenBefore = "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4",
+            ply = 30,
+            moveLan = "e1g1",
+            analysis = cp(30, "d2d3"),
+            nextAnalysis = cp(80, "f8c5"),
+            lossCp = 150
+        )
+        assertTrue(ThemeTag.MIDDLEGAME in middlegame)
+        assertFalse(ThemeTag.OPENING in middlegame)
+        assertFalse(ThemeTag.ENDGAME in middlegame)
+    }
+}

--- a/app/src/test/java/com/raichess/domain/usecase/ThemeTaggerTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/ThemeTaggerTest.kt
@@ -98,7 +98,7 @@ class ThemeTaggerTest {
             ply = 58,
             moveLan = "a2a3",
             analysis = cp(-200, "b1b8"),
-            nextAnalysis = cp(450, "h8b8"),
+            nextAnalysis = cp(450, "h1b1"),
             lossCp = 300
         )
         assertTrue(ThemeTag.ALLOWED_TACTIC in tags)

--- a/app/src/test/java/com/raichess/domain/usecase/WeaknessProfilerTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/WeaknessProfilerTest.kt
@@ -18,8 +18,8 @@ class WeaknessProfilerTest {
                 obs(WeaknessProfiler.HALF_LIFE_GAMES.toInt(), ThemeTag.MISSED_CAPTURE)
             )
         )
-        val hanging = profile.first { it.theme == ThemeTag.HANGING_PIECE }
-        val missed = profile.first { it.theme == ThemeTag.MISSED_CAPTURE }
+        val hanging = profile.weaknesses.first { it.theme == ThemeTag.HANGING_PIECE }
+        val missed = profile.weaknesses.first { it.theme == ThemeTag.MISSED_CAPTURE }
         assertEquals(1.0, hanging.score, 1e-9)
         assertEquals(0.5, missed.score, 1e-9)
     }
@@ -37,10 +37,27 @@ class WeaknessProfilerTest {
                 obs(80, ThemeTag.MISSED_CAPTURE)
             )
         )
-        assertEquals(ThemeTag.HANGING_PIECE, profile.first().theme)
-        val old = profile.first { it.theme == ThemeTag.MISSED_CAPTURE }
+        assertEquals(ThemeTag.HANGING_PIECE, profile.weaknesses.first().theme)
+        val old = profile.weaknesses.first { it.theme == ThemeTag.MISSED_CAPTURE }
         assertEquals(3, old.occurrences) // raw count preserved for display
         assertTrue(old.score < 0.25)     // but the weight has decayed away
+    }
+
+    @Test
+    fun `phase tags rank separately from substantive weaknesses`() {
+        // Every observation carries a phase tag, so mixed ranking would put
+        // MIDDLEGAME on top by construction — the split keeps the actionable
+        // weakness first in its own list.
+        val profile = WeaknessProfiler.build(
+            listOf(
+                obs(0, ThemeTag.HANGING_PIECE, ThemeTag.MIDDLEGAME),
+                obs(1, ThemeTag.MIDDLEGAME),
+                obs(2, ThemeTag.MIDDLEGAME)
+            )
+        )
+        assertEquals(ThemeTag.HANGING_PIECE, profile.weaknesses.single().theme)
+        assertEquals(ThemeTag.MIDDLEGAME, profile.phases.single().theme)
+        assertEquals(3, profile.phases.single().occurrences)
     }
 
     @Test
@@ -48,8 +65,10 @@ class WeaknessProfilerTest {
         val profile = WeaknessProfiler.build(
             listOf(obs(0, ThemeTag.HANGING_PIECE, ThemeTag.ENDGAME, lossCp = 500))
         )
-        assertEquals(2, profile.size)
-        assertTrue(profile.all { it.avgLossCp == 500.0 && it.occurrences == 1 })
+        assertEquals(1, profile.weaknesses.size)
+        assertEquals(1, profile.phases.size)
+        val all = profile.weaknesses + profile.phases
+        assertTrue(all.all { it.avgLossCp == 500.0 && it.occurrences == 1 })
     }
 
     @Test
@@ -61,12 +80,22 @@ class WeaknessProfilerTest {
                 obs(1, ThemeTag.MISSED_MATE, lossCp = 1000)
             )
         )
-        assertEquals(600.0, profile.first { it.theme == ThemeTag.HANGING_PIECE }.avgLossCp, 1e-9)
-        assertEquals(1000.0, profile.first { it.theme == ThemeTag.MISSED_MATE }.avgLossCp, 1e-9)
+        assertEquals(
+            600.0,
+            profile.weaknesses.first { it.theme == ThemeTag.HANGING_PIECE }.avgLossCp,
+            1e-9
+        )
+        assertEquals(
+            1000.0,
+            profile.weaknesses.first { it.theme == ThemeTag.MISSED_MATE }.avgLossCp,
+            1e-9
+        )
     }
 
     @Test
     fun `empty history yields an empty profile`() {
-        assertTrue(WeaknessProfiler.build(emptyList()).isEmpty())
+        val profile = WeaknessProfiler.build(emptyList())
+        assertTrue(profile.weaknesses.isEmpty())
+        assertTrue(profile.phases.isEmpty())
     }
 }

--- a/app/src/test/java/com/raichess/domain/usecase/WeaknessProfilerTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/WeaknessProfilerTest.kt
@@ -1,0 +1,72 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.ThemeTag
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WeaknessProfilerTest {
+
+    private fun obs(gamesAgo: Int, vararg themes: ThemeTag, lossCp: Int = 300) =
+        MistakeObservation(gamesAgo, themes.toSet(), lossCp)
+
+    @Test
+    fun `weight halves at the half-life`() {
+        val profile = WeaknessProfiler.build(
+            listOf(
+                obs(0, ThemeTag.HANGING_PIECE),
+                obs(WeaknessProfiler.HALF_LIFE_GAMES.toInt(), ThemeTag.MISSED_CAPTURE)
+            )
+        )
+        val hanging = profile.first { it.theme == ThemeTag.HANGING_PIECE }
+        val missed = profile.first { it.theme == ThemeTag.MISSED_CAPTURE }
+        assertEquals(1.0, hanging.score, 1e-9)
+        assertEquals(0.5, missed.score, 1e-9)
+    }
+
+    @Test
+    fun `recent mistakes outrank frequent-but-old ones`() {
+        // Two hangs from the latest games vs. three missed captures ~4 half-lives ago:
+        // the old habit has decayed below the current one.
+        val profile = WeaknessProfiler.build(
+            listOf(
+                obs(0, ThemeTag.HANGING_PIECE),
+                obs(1, ThemeTag.HANGING_PIECE),
+                obs(80, ThemeTag.MISSED_CAPTURE),
+                obs(80, ThemeTag.MISSED_CAPTURE),
+                obs(80, ThemeTag.MISSED_CAPTURE)
+            )
+        )
+        assertEquals(ThemeTag.HANGING_PIECE, profile.first().theme)
+        val old = profile.first { it.theme == ThemeTag.MISSED_CAPTURE }
+        assertEquals(3, old.occurrences) // raw count preserved for display
+        assertTrue(old.score < 0.25)     // but the weight has decayed away
+    }
+
+    @Test
+    fun `one observation feeds every theme it carries`() {
+        val profile = WeaknessProfiler.build(
+            listOf(obs(0, ThemeTag.HANGING_PIECE, ThemeTag.ENDGAME, lossCp = 500))
+        )
+        assertEquals(2, profile.size)
+        assertTrue(profile.all { it.avgLossCp == 500.0 && it.occurrences == 1 })
+    }
+
+    @Test
+    fun `average severity is per theme`() {
+        val profile = WeaknessProfiler.build(
+            listOf(
+                obs(0, ThemeTag.HANGING_PIECE, lossCp = 900),
+                obs(2, ThemeTag.HANGING_PIECE, lossCp = 300),
+                obs(1, ThemeTag.MISSED_MATE, lossCp = 1000)
+            )
+        )
+        assertEquals(600.0, profile.first { it.theme == ThemeTag.HANGING_PIECE }.avgLossCp, 1e-9)
+        assertEquals(1000.0, profile.first { it.theme == ThemeTag.MISSED_MATE }.avgLossCp, 1e-9)
+    }
+
+    @Test
+    fun `empty history yields an empty profile`() {
+        assertTrue(WeaknessProfiler.build(emptyList()).isEmpty())
+    }
+}


### PR DESCRIPTION
Phase B of the coaching roadmap: turn Phase A's stored observations into a picture of the player. Also carries a small durability fix to Phase A.

## Theme tagging (`ThemeTag`, `ThemeTagger`)

Rule-based tagging of graded mistakes using board geometry plus the evals `GameAnalyzer` already produced — no extra engine calls:

- **What the move gave away:** `hanging_piece` (moved piece landed attacked and under-defended), `allowed_tactic` (opponent's best reply wins significant material elsewhere), `allowed_mate`
- **What was available and not taken:** `missed_mate`, `missed_capture`
- **Game phase:** `opening` / `middlegame` / `endgame` (piece count takes precedence over ply)

Deliberately conservative: tags only attach at mistake-or-worse loss (≥100cp), and each detector prefers missing a tag over inventing one, because the profile amplifies whatever is stored. Themes go into the `positions` table's reserved `themes` column as CSV (`GameAnalyzer` bumped to v2); unknown ids are skipped on read so the taxonomy can grow without migrations.

## Weakness profile (`WeaknessProfiler`, `GameRepository.weaknessProfile()`)

The derived, never-persisted profile that Phase C's personalized hints and the practice queue will read. Each mistake observation is weighted `0.5^(gamesAgo / 20)` — a weakness the player has outgrown decays out of the profile instead of following them forever, which is the core "leave room for skills to evolve" requirement. Raw occurrence counts and average centipawn loss per theme are kept alongside the decayed score for display.

## Phase A follow-up fix

The Room migration had moved the undo→practice-position write onto `viewModelScope`, so leaving the game screen right after an undo could cancel the write and silently drop the observation (the pre-migration SharedPreferences write survived that). `PracticeRepository.recordMistakePosition` now runs the write on a repository-owned, process-lifetime scope.

## Tests

- Tagger detectors against crafted FENs: hanging queen (Qh5?? vs ...g6), back-rank missed mate, missed free queen, fool's-mate allowed mate, the allowed-tactic vs hanging-piece distinction, phase precedence, and the below-threshold no-tags gate
- Profiler math: half-life weighting, recent-vs-frequent ranking, per-theme severity, multi-theme observations, empty history
- Theme CSV round-trip and forward-compatibility (unknown ids skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p)_