### PR TITLE
feat: Phase C of coaching roadmap — hints, live move rating, and win chances in Training mode

### DIFF
--- a/app/src/main/java/com/raichess/MainActivity.kt
+++ b/app/src/main/java/com/raichess/MainActivity.kt
@@ -65,6 +65,7 @@ fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
             state = state,
             onSquareTapped = viewModel::onSquareTapped,
             onUndo = viewModel::undoMove,
+            onHint = viewModel::requestHint,
             onResign = viewModel::resign,
             onNewGame = viewModel::backToSetup
         )

--- a/app/src/main/java/com/raichess/data/engine/ChessEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/ChessEngine.kt
@@ -34,7 +34,12 @@ interface ChessEngine {
      * Unlike [selectMove] this is never strength-limited — it powers
      * post-game analysis and coaching, where an honest eval is the point.
      * Same threading contract as [selectMove]: single sequential caller, off
-     * the UI thread, and [board] is left in its original state.
+     * the UI thread, and [board] is left in its original state. The
+     * single-caller rule covers analyze() and selectMove() TOGETHER on one
+     * instance: implementations may temporarily mutate shared engine state
+     * during analysis (e.g. StockfishWasmEngine lifts its Skill Level cap),
+     * so an unserialized selectMove could silently play at the wrong
+     * strength.
      *
      * @param moveTimeMs search budget; fixed-depth implementations may ignore it
      */

--- a/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
@@ -126,6 +126,10 @@ class StockfishWasmEngine(
             try {
                 analyzeAtCurrentStrength(board, moveTimeMs)
             } finally {
+                // Fire-and-forget restore, not synchronous: safe because
+                // send() posts to one main-thread Handler (FIFO), so this is
+                // guaranteed to run before any command a later engine call
+                // enqueues. Don't "fix" this into a blocking wait.
                 if (liftSkillLimit) config.getUciCommands().forEach { send(it) }
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
@@ -117,48 +117,62 @@ class StockfishWasmEngine(
             if (!ensureReady()) return fallbackAnalysis(board, moveTimeMs)
             if (released) return null
 
-            output.clear()
-            // No ucinewgame between analyze() calls — including across
-            // different games when one engine drains a backlog: the
-            // transposition table is keyed by position, so entries from
-            // another game are irrelevant or helpful, never wrong, and a
-            // warm hash makes sequential analysis faster.
-            send("position fen ${board.fen}")
-            send("go movetime $moveTimeMs")
-
-            // Track the best info line while waiting for the bestmove
-            // terminator. Bound scores (fail-high/low) are only reported
-            // mid-resolution, so exact scores are preferred; multipv is
-            // always 1 here but filtered defensively for when hints add
-            // MultiPV search.
-            var lastInfo: UciInfoParser.UciInfo? = null
-            val best = awaitToken(moveTimeMs + BESTMOVE_GRACE_MS) { line ->
-                UciInfoParser.parse(line)?.let { info ->
-                    if (info.multipv == 1 && !info.isBound) lastInfo = info
-                }
-                line.startsWith("bestmove")
+            // Keep the interface's "never strength-limited" promise on play
+            // instances too: lift the Skill Level handicap for this search
+            // and restore it afterwards, so in-game hints/coaching get an
+            // honest eval without permanently strengthening the opponent.
+            val liftSkillLimit = !analysisMode && config.skillLevel < MAX_SKILL_LEVEL
+            if (liftSkillLimit) send("setoption name Skill Level value $MAX_SKILL_LEVEL")
+            try {
+                analyzeAtCurrentStrength(board, moveTimeMs)
+            } finally {
+                if (liftSkillLimit) config.getUciCommands().forEach { send(it) }
             }
-            if (best == null) {
-                if (released) return null
-                Log.w(TAG, "no bestmove within analysis timeout; using fallback analyzer")
-                return fallbackAnalysis(board, moveTimeMs)
-            }
-
-            val info = lastInfo ?: return fallbackAnalysis(board, moveTimeMs)
-            // Re-validate the engine's move against the real legal set, as
-            // selectMove does; "bestmove (none)" (mate/stalemate) → null.
-            val bestMoveLan = parseUciBestMove(board, best)?.toString()?.lowercase()
-            PositionAnalysis(
-                scoreCp = info.scoreCp,
-                mateIn = info.scoreMate,
-                bestMoveLan = bestMoveLan,
-                pv = info.pv.map { it.lowercase() },
-                depth = info.depth
-            )
         } catch (e: Exception) {
             Log.w(TAG, "analyze failed; using fallback analyzer", e)
             fallbackAnalysis(board, moveTimeMs)
         }
+    }
+
+    private fun analyzeAtCurrentStrength(board: Board, moveTimeMs: Long): PositionAnalysis? {
+        output.clear()
+        // No ucinewgame between analyze() calls — including across
+        // different games when one engine drains a backlog: the
+        // transposition table is keyed by position, so entries from
+        // another game are irrelevant or helpful, never wrong, and a
+        // warm hash makes sequential analysis faster.
+        send("position fen ${board.fen}")
+        send("go movetime $moveTimeMs")
+
+        // Track the best info line while waiting for the bestmove
+        // terminator. Bound scores (fail-high/low) are only reported
+        // mid-resolution, so exact scores are preferred; multipv is
+        // always 1 here but filtered defensively for when hints add
+        // MultiPV search.
+        var lastInfo: UciInfoParser.UciInfo? = null
+        val best = awaitToken(moveTimeMs + BESTMOVE_GRACE_MS) { line ->
+            UciInfoParser.parse(line)?.let { info ->
+                if (info.multipv == 1 && !info.isBound) lastInfo = info
+            }
+            line.startsWith("bestmove")
+        }
+        if (best == null) {
+            if (released) return null
+            Log.w(TAG, "no bestmove within analysis timeout; using fallback analyzer")
+            return fallbackAnalysis(board, moveTimeMs)
+        }
+
+        val info = lastInfo ?: return fallbackAnalysis(board, moveTimeMs)
+        // Re-validate the engine's move against the real legal set, as
+        // selectMove does; "bestmove (none)" (mate/stalemate) → null.
+        val bestMoveLan = parseUciBestMove(board, best)?.toString()?.lowercase()
+        return PositionAnalysis(
+            scoreCp = info.scoreCp,
+            mateIn = info.scoreMate,
+            bestMoveLan = bestMoveLan,
+            pv = info.pv.map { it.lowercase() },
+            depth = info.depth
+        )
     }
 
     /** Serve an analysis from the RaiEngine fallback and remember that we did. */
@@ -353,6 +367,8 @@ class StockfishWasmEngine(
         }
 
         private const val TAG = "StockfishWasmEngine"
+        /** Stockfish's Skill Level ceiling — full strength. */
+        private const val MAX_SKILL_LEVEL = 20
         private const val ASSET_HOST = "appassets.androidplatform.net"
         private const val READY_SENTINEL = "__ready__"
         private const val ERROR_SENTINEL = "__error__"

--- a/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/StockfishWasmEngine.kt
@@ -179,9 +179,14 @@ class StockfishWasmEngine(
         )
     }
 
-    /** Serve an analysis from the RaiEngine fallback and remember that we did. */
+    /**
+     * Serve an analysis from the RaiEngine fallback. Deliberately does NOT
+     * set [everFellBack]: that flag drives the UI's opponent-engine label,
+     * which must reflect who is serving *moves* — a single slow coaching
+     * analysis on a play instance must not brand the whole game
+     * "RaiEngine (fallback)" while Stockfish keeps playing.
+     */
     private fun fallbackAnalysis(board: Board, moveTimeMs: Long): PositionAnalysis? {
-        everFellBack = true
         return fallback.analyze(board, moveTimeMs)
     }
 

--- a/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
+++ b/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
@@ -47,6 +47,17 @@ object MoveClassifier {
     fun centipawnLoss(evalBeforeCp: Int, evalAfterCp: Int): Int =
         max(0, evalBeforeCp - evalAfterCp)
 
+    /**
+     * Centipawns lost by the move that turned [before] into [after], both
+     * engine verdicts from their own side-to-move's perspective — so
+     * [before] is from the mover's view and [after] from the opponent's,
+     * and the sign flip back to the mover happens here, in exactly one
+     * tested place. Used by the live coach; GameAnalyzer does the same
+     * flip against terminal-position evals that have no analysis object.
+     */
+    fun lossBetween(before: PositionAnalysis, after: PositionAnalysis): Int =
+        centipawnLoss(before.effectiveCp(), -after.effectiveCp())
+
     fun classify(centipawnLoss: Int, playedEngineBest: Boolean): MoveClassification = when {
         playedEngineBest -> MoveClassification.BEST
         centipawnLoss < INACCURACY_THRESHOLD_CP -> MoveClassification.GOOD

--- a/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
+++ b/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
@@ -34,7 +34,9 @@ object MoveClassifier {
 
     /** Public: ThemeTagger and the weakness profile gate on mistake-or-worse. */
     const val MISTAKE_THRESHOLD_CP = 100
-    private const val BLUNDER_THRESHOLD_CP = 300
+
+    /** Public: the live coach warns at blunder-level loss. */
+    const val BLUNDER_THRESHOLD_CP = 300
 
     /**
      * Centipawns thrown away by a move, never negative. Both arguments are

--- a/app/src/main/java/com/raichess/domain/model/UndoPenalty.kt
+++ b/app/src/main/java/com/raichess/domain/model/UndoPenalty.kt
@@ -1,7 +1,8 @@
 package com.raichess.domain.model
 
 /**
- * Maps Training-mode undo usage to the moveAccuracy input of
+ * Maps Training-mode assistance (undos plus revealed hint rungs — callers
+ * pass the combined count) to the moveAccuracy input of
  * [EloCalculator.calculateNewElo].
  *
  * Accuracy 50 is neutral. The calculator applies

--- a/app/src/main/java/com/raichess/domain/model/WinProbability.kt
+++ b/app/src/main/java/com/raichess/domain/model/WinProbability.kt
@@ -1,0 +1,24 @@
+package com.raichess.domain.model
+
+import kotlin.math.exp
+import kotlin.math.roundToInt
+
+/**
+ * Maps a centipawn evaluation to a winning-chances percentage for the live
+ * move-rating display, using the Lichess-style logistic curve
+ * (2 / (1 + e^(-0.00368208·cp)) − 1, rescaled to 0–100%). 0cp → 50%,
+ * ±300cp → ~75%/25%, mate-capped ±1000cp → ~97%/3%.
+ *
+ * A calibration convenience for display, not a statistical claim — the
+ * curve's shape (monotonic, symmetric, saturating) is what matters.
+ */
+object WinProbability {
+
+    private const val SCALE = 0.00368208
+
+    /** Win percentage 0..100 from an eval in the player's perspective. */
+    fun percent(cpFromPlayerPerspective: Int): Int {
+        val chances = 2.0 / (1.0 + exp(-SCALE * cpFromPlayerPerspective)) - 1.0
+        return (((chances + 1.0) / 2.0) * 100.0).roundToInt().coerceIn(0, 100)
+    }
+}

--- a/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
@@ -1,29 +1,19 @@
 package com.raichess.domain.usecase
 
 import com.raichess.domain.model.PositionAnalysis
-import com.raichess.domain.model.ThemeTag
 
 /**
- * Content for the progressive hint ladder (Phase C of the coaching
- * roadmap). Each rung reveals more so a hint teaches before it solves:
- *
- * 1. A nudge — personalized from the player's top weakness when the
- *    position doesn't offer a more specific cue (mate/material available).
- * 2. The piece to look at (highlights the from-square).
- * 3. The move itself (highlights both squares).
+ * Content for the two-rung hint ladder: rung 1 points at the piece to
+ * look at (name + square highlight), rung 2 shows the exact move. A text
+ * nudge rung was tried and dropped — it read as encouragement rather than
+ * help; pointing at the board is the hint.
  *
  * Pure content selection over an already-computed [PositionAnalysis] —
- * no engine calls, no Android types, fully unit-testable.
+ * no engine calls, no Android/chesslib types, fully unit-testable.
  */
 object HintAdvisor {
 
-    const val MAX_LEVEL = 3
-
-    /** Captures below this many centipawns don't trigger the material nudge. */
-    private const val SIGNIFICANT_CAPTURE_CP = 300
-
-    /** The material nudge also needs the eval to actually favor the mover. */
-    private const val MATERIAL_NUDGE_MIN_EVAL_CP = 150
+    const val MAX_LEVEL = 2
 
     data class Hint(
         val text: String,
@@ -35,75 +25,28 @@ object HintAdvisor {
      * The hint for [level] (1..[MAX_LEVEL]), or null when no hint can be
      * given (no best move known, malformed data, level out of range).
      *
-     * @param squares FEN piece chars indexed a1=0..h8=63 (the UI's snapshot)
-     * @param topWeakness the player's current worst substantive theme, if any
+     * @param fen the position the analysis was computed for
      */
-    fun hint(
-        level: Int,
-        analysis: PositionAnalysis,
-        squares: List<Char?>,
-        topWeakness: ThemeTag? = null
-    ): Hint? {
-        val best = analysis.bestMoveLan ?: return null
-        if (best.length < 4) return null
-        val fromLan = best.substring(0, 2)
-        val toLan = best.substring(2, 4)
+    fun hint(level: Int, analysis: PositionAnalysis, fen: String): Hint? {
+        val bestLan = analysis.bestMoveLan ?: return null
+        if (bestLan.length < 4) return null
+        val fromLan = bestLan.substring(0, 2)
+        val toLan = bestLan.substring(2, 4)
         val from = squareOrdinal(fromLan) ?: return null
         val to = squareOrdinal(toLan) ?: return null
 
         return when (level) {
-            1 -> Hint(nudgeText(analysis, squares, to, topWeakness), emptySet())
-            2 -> {
-                val piece = squares.getOrNull(from)?.let { pieceName(it) } ?: "piece"
+            1 -> {
+                val piece = parseFenBoard(fen)?.getOrNull(from)
+                    ?.let { pieceName(it) } ?: "piece"
                 Hint("Look at your $piece on $fromLan.", setOf(from))
             }
-            3 -> {
-                val promotion = best.getOrNull(4)?.let { " (promote to ${pieceName(it)})" } ?: ""
-                Hint("Best move: $fromLan → $toLan$promotion.", setOf(from, to))
+            2 -> {
+                val promotion = bestLan.getOrNull(4)
+                    ?.let { " (promote to ${pieceName(it)})" } ?: ""
+                Hint("Play $fromLan → $toLan$promotion.", setOf(from, to))
             }
             else -> null
-        }
-    }
-
-    /**
-     * Rung 1: what's true about the position wins over the profile —
-     * a mate or material cue is more useful than a general habit reminder.
-     */
-    private fun nudgeText(
-        analysis: PositionAnalysis,
-        squares: List<Char?>,
-        bestMoveTarget: Int,
-        topWeakness: ThemeTag?
-    ): String {
-        val mate = analysis.mateIn
-        if (mate != null && mate > 0) {
-            return "You have a forced mate — look for checks."
-        }
-        // Reads the destination square, so an en passant capture falls
-        // through to the personalized/generic nudge — a known gap in the
-        // "prefer under-hinting" direction (and ep never clears the 300cp
-        // significance floor anyway). The eval gate filters out even
-        // trades: queen-takes-queen with a recapture is not "winning
-        // material", and the eval already reflects the exchange honestly.
-        val capturedPiece = squares.getOrNull(bestMoveTarget)
-        if (capturedPiece != null &&
-            pieceValue(capturedPiece) >= SIGNIFICANT_CAPTURE_CP &&
-            analysis.effectiveCp() >= MATERIAL_NUDGE_MIN_EVAL_CP
-        ) {
-            return "You can win material this move — look for captures."
-        }
-        return when (topWeakness) {
-            ThemeTag.HANGING_PIECE ->
-                "Check that your pieces are defended before you commit — loose pieces have been costing you."
-            ThemeTag.MISSED_CAPTURE ->
-                "You've been letting captures slip by — is anything takeable?"
-            ThemeTag.MISSED_MATE ->
-                "You've missed forcing wins before — any checks worth a look?"
-            ThemeTag.ALLOWED_TACTIC ->
-                "Ask what your opponent's best reply would win — replies have been hurting you."
-            ThemeTag.ALLOWED_MATE ->
-                "Mind your king's safety before committing."
-            else -> "There's a stronger move here — take another look."
         }
     }
 
@@ -116,6 +59,32 @@ object HintAdvisor {
         return rank * 8 + file
     }
 
+    /**
+     * Parse a FEN's piece-placement field into FEN chars indexed a1=0..h8=63
+     * (nulls for empty squares), or null if malformed.
+     */
+    fun parseFenBoard(fen: String): List<Char?>? {
+        val placement = fen.trim().split(' ').firstOrNull() ?: return null
+        val rankStrings = placement.split('/')
+        if (rankStrings.size != 8) return null
+        val board = arrayOfNulls<Char>(64)
+        for ((i, rankString) in rankStrings.withIndex()) {
+            val rank = 7 - i // FEN lists rank 8 first
+            var file = 0
+            for (c in rankString) {
+                if (c.isDigit()) {
+                    file += c - '0'
+                } else {
+                    if (file > 7) return null
+                    board[rank * 8 + file] = c
+                    file++
+                }
+            }
+            if (file != 8) return null
+        }
+        return board.toList()
+    }
+
     private fun pieceName(fenChar: Char): String = when (fenChar.lowercaseChar()) {
         'p' -> "pawn"
         'n' -> "knight"
@@ -124,14 +93,5 @@ object HintAdvisor {
         'q' -> "queen"
         'k' -> "king"
         else -> "piece"
-    }
-
-    private fun pieceValue(fenChar: Char): Int = when (fenChar.lowercaseChar()) {
-        'p' -> 100
-        'n' -> 320
-        'b' -> 330
-        'r' -> 500
-        'q' -> 900
-        else -> 0
     }
 }

--- a/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
@@ -1,0 +1,122 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.PositionAnalysis
+import com.raichess.domain.model.ThemeTag
+
+/**
+ * Content for the progressive hint ladder (Phase C of the coaching
+ * roadmap). Each rung reveals more so a hint teaches before it solves:
+ *
+ * 1. A nudge — personalized from the player's top weakness when the
+ *    position doesn't offer a more specific cue (mate/material available).
+ * 2. The piece to look at (highlights the from-square).
+ * 3. The move itself (highlights both squares).
+ *
+ * Pure content selection over an already-computed [PositionAnalysis] —
+ * no engine calls, no Android types, fully unit-testable.
+ */
+object HintAdvisor {
+
+    const val MAX_LEVEL = 3
+
+    /** Captures below this many centipawns don't trigger the material nudge. */
+    private const val SIGNIFICANT_CAPTURE_CP = 300
+
+    data class Hint(
+        val text: String,
+        /** Board square ordinals (a1=0 .. h8=63) to highlight. */
+        val highlights: Set<Int>
+    )
+
+    /**
+     * The hint for [level] (1..[MAX_LEVEL]), or null when no hint can be
+     * given (no best move known, malformed data, level out of range).
+     *
+     * @param squares FEN piece chars indexed a1=0..h8=63 (the UI's snapshot)
+     * @param topWeakness the player's current worst substantive theme, if any
+     */
+    fun hint(
+        level: Int,
+        analysis: PositionAnalysis,
+        squares: List<Char?>,
+        topWeakness: ThemeTag? = null
+    ): Hint? {
+        val best = analysis.bestMoveLan ?: return null
+        if (best.length < 4) return null
+        val fromLan = best.substring(0, 2)
+        val toLan = best.substring(2, 4)
+        val from = squareOrdinal(fromLan) ?: return null
+        val to = squareOrdinal(toLan) ?: return null
+
+        return when (level) {
+            1 -> Hint(nudgeText(analysis, squares, to, topWeakness), emptySet())
+            2 -> {
+                val piece = squares.getOrNull(from)?.let { pieceName(it) } ?: "piece"
+                Hint("Look at your $piece on $fromLan.", setOf(from))
+            }
+            3 -> Hint("Best move: $fromLan → $toLan.", setOf(from, to))
+            else -> null
+        }
+    }
+
+    /**
+     * Rung 1: what's true about the position wins over the profile —
+     * a mate or material cue is more useful than a general habit reminder.
+     */
+    private fun nudgeText(
+        analysis: PositionAnalysis,
+        squares: List<Char?>,
+        bestMoveTarget: Int,
+        topWeakness: ThemeTag?
+    ): String {
+        val mate = analysis.mateIn
+        if (mate != null && mate > 0) {
+            return "You have a forced mate — look for checks."
+        }
+        val capturedPiece = squares.getOrNull(bestMoveTarget)
+        if (capturedPiece != null && pieceValue(capturedPiece) >= SIGNIFICANT_CAPTURE_CP) {
+            return "You can win material this move — look for captures."
+        }
+        return when (topWeakness) {
+            ThemeTag.HANGING_PIECE ->
+                "Check that your pieces are defended before you commit — loose pieces have been costing you."
+            ThemeTag.MISSED_CAPTURE ->
+                "You've been letting captures slip by — is anything takeable?"
+            ThemeTag.MISSED_MATE ->
+                "You've missed forcing wins before — any checks worth a look?"
+            ThemeTag.ALLOWED_TACTIC ->
+                "Ask what your opponent's best reply would win — replies have been hurting you."
+            ThemeTag.ALLOWED_MATE ->
+                "Mind your king's safety before committing."
+            else -> "There's a stronger move here — take another look."
+        }
+    }
+
+    /** "e2" → 12 (a1=0..h8=63), or null if malformed. */
+    fun squareOrdinal(lanSquare: String): Int? {
+        if (lanSquare.length != 2) return null
+        val file = lanSquare[0] - 'a'
+        val rank = lanSquare[1] - '1'
+        if (file !in 0..7 || rank !in 0..7) return null
+        return rank * 8 + file
+    }
+
+    private fun pieceName(fenChar: Char): String = when (fenChar.lowercaseChar()) {
+        'p' -> "pawn"
+        'n' -> "knight"
+        'b' -> "bishop"
+        'r' -> "rook"
+        'q' -> "queen"
+        'k' -> "king"
+        else -> "piece"
+    }
+
+    private fun pieceValue(fenChar: Char): Int = when (fenChar.lowercaseChar()) {
+        'p' -> 100
+        'n' -> 320
+        'b' -> 330
+        'r' -> 500
+        'q' -> 900
+        else -> 0
+    }
+}

--- a/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
@@ -73,6 +73,10 @@ object HintAdvisor {
         if (mate != null && mate > 0) {
             return "You have a forced mate — look for checks."
         }
+        // Reads the destination square, so an en passant capture falls
+        // through to the personalized/generic nudge — a known gap in the
+        // "prefer under-hinting" direction (and ep never clears the 300cp
+        // significance floor anyway).
         val capturedPiece = squares.getOrNull(bestMoveTarget)
         if (capturedPiece != null && pieceValue(capturedPiece) >= SIGNIFICANT_CAPTURE_CP) {
             return "You can win material this move — look for captures."

--- a/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
@@ -57,7 +57,10 @@ object HintAdvisor {
                 val piece = squares.getOrNull(from)?.let { pieceName(it) } ?: "piece"
                 Hint("Look at your $piece on $fromLan.", setOf(from))
             }
-            3 -> Hint("Best move: $fromLan → $toLan.", setOf(from, to))
+            3 -> {
+                val promotion = best.getOrNull(4)?.let { " (promote to ${pieceName(it)})" } ?: ""
+                Hint("Best move: $fromLan → $toLan$promotion.", setOf(from, to))
+            }
             else -> null
         }
     }

--- a/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
@@ -3,17 +3,22 @@ package com.raichess.domain.usecase
 import com.raichess.domain.model.PositionAnalysis
 
 /**
- * Content for the two-rung hint ladder: rung 1 points at the piece to
- * look at (name + square highlight), rung 2 shows the exact move. A text
- * nudge rung was tried and dropped — it read as encouragement rather than
- * help; pointing at the board is the hint.
+ * Content for the hint ladder: rung 1 points at the piece to look at
+ * (name + square highlight), rung 2 shows the exact move, rung 3 shows
+ * the move a deeper engine search settles on (the caller runs the longer
+ * search and passes its result here). A text nudge rung was tried and
+ * dropped — it read as encouragement rather than help; pointing at the
+ * board is the hint.
  *
  * Pure content selection over an already-computed [PositionAnalysis] —
  * no engine calls, no Android/chesslib types, fully unit-testable.
  */
 object HintAdvisor {
 
-    const val MAX_LEVEL = 2
+    const val MAX_LEVEL = 3
+
+    /** The rung whose content requires a fresh, deeper engine search. */
+    const val DEEP_LEVEL = 3
 
     data class Hint(
         val text: String,
@@ -45,6 +50,11 @@ object HintAdvisor {
                 val promotion = bestLan.getOrNull(4)
                     ?.let { " (promote to ${pieceName(it)})" } ?: ""
                 Hint("Play $fromLan → $toLan$promotion.", setOf(from, to))
+            }
+            DEEP_LEVEL -> {
+                val promotion = bestLan.getOrNull(4)
+                    ?.let { " (promote to ${pieceName(it)})" } ?: ""
+                Hint("After a deeper look: play $fromLan → $toLan$promotion.", setOf(from, to))
             }
             else -> null
         }

--- a/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
@@ -46,19 +46,20 @@ object HintAdvisor {
                     ?.let { pieceName(it) } ?: "piece"
                 Hint("Look at your $piece on $fromLan.", setOf(from))
             }
-            2 -> {
-                val promotion = bestLan.getOrNull(4)
-                    ?.let { " (promote to ${pieceName(it)})" } ?: ""
-                Hint("Play $fromLan → $toLan$promotion.", setOf(from, to))
-            }
-            DEEP_LEVEL -> {
-                val promotion = bestLan.getOrNull(4)
-                    ?.let { " (promote to ${pieceName(it)})" } ?: ""
-                Hint("After a deeper look: play $fromLan → $toLan$promotion.", setOf(from, to))
-            }
+            2 -> Hint(
+                "Play $fromLan → $toLan${promotionSuffix(bestLan)}.",
+                setOf(from, to)
+            )
+            DEEP_LEVEL -> Hint(
+                "After a deeper look: play $fromLan → $toLan${promotionSuffix(bestLan)}.",
+                setOf(from, to)
+            )
             else -> null
         }
     }
+
+    private fun promotionSuffix(bestLan: String): String =
+        bestLan.getOrNull(4)?.let { " (promote to ${pieceName(it)})" } ?: ""
 
     /** "e2" → 12 (a1=0..h8=63), or null if malformed. */
     fun squareOrdinal(lanSquare: String): Int? {

--- a/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/HintAdvisor.kt
@@ -22,6 +22,9 @@ object HintAdvisor {
     /** Captures below this many centipawns don't trigger the material nudge. */
     private const val SIGNIFICANT_CAPTURE_CP = 300
 
+    /** The material nudge also needs the eval to actually favor the mover. */
+    private const val MATERIAL_NUDGE_MIN_EVAL_CP = 150
+
     data class Hint(
         val text: String,
         /** Board square ordinals (a1=0 .. h8=63) to highlight. */
@@ -76,9 +79,14 @@ object HintAdvisor {
         // Reads the destination square, so an en passant capture falls
         // through to the personalized/generic nudge — a known gap in the
         // "prefer under-hinting" direction (and ep never clears the 300cp
-        // significance floor anyway).
+        // significance floor anyway). The eval gate filters out even
+        // trades: queen-takes-queen with a recapture is not "winning
+        // material", and the eval already reflects the exchange honestly.
         val capturedPiece = squares.getOrNull(bestMoveTarget)
-        if (capturedPiece != null && pieceValue(capturedPiece) >= SIGNIFICANT_CAPTURE_CP) {
+        if (capturedPiece != null &&
+            pieceValue(capturedPiece) >= SIGNIFICANT_CAPTURE_CP &&
+            analysis.effectiveCp() >= MATERIAL_NUDGE_MIN_EVAL_CP
+        ) {
             return "You can win material this move — look for captures."
         }
         return when (topWeakness) {

--- a/app/src/main/java/com/raichess/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameScreen.kt
@@ -38,11 +38,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.raichess.domain.model.GameMode
 import com.raichess.domain.model.MaterialCalculator
+import com.raichess.domain.model.MoveClassification
 import com.raichess.domain.model.PlayerColor
 import com.raichess.domain.usecase.HintAdvisor
 import com.raichess.ui.theme.ChessColors
@@ -93,21 +96,26 @@ fun GameScreen(
             modifier = Modifier.padding(vertical = 6.dp)
         )
 
-        // Coach line: a hint the player asked for, or a passive warning
-        // that the last move lost serious ground (Training mode only)
-        val coachText = state.hintText?.let { "Hint: $it" }
-            ?: if (state.coachWarning) {
-                "Coach: that last move may have lost ground — consider Undo."
-            } else {
-                null
+        // Coach line (Training): a requested hint, else the live move
+        // rating and win chances. Fixed-height slot so the board never
+        // reflows when text appears or disappears.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(coachLineHeight),
+            contentAlignment = Alignment.Center
+        ) {
+            val coachText = state.hintText?.let { "Hint: $it" } ?: coachStatusLine(state)
+            if (coachText != null) {
+                Text(
+                    text = coachText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
-        if (coachText != null) {
-            Text(
-                text = coachText,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onBackground,
-                modifier = Modifier.padding(bottom = 4.dp)
-            )
         }
 
         CapturedRow(pieces = opponentCaptures, advantage = -playerDiff)
@@ -460,6 +468,29 @@ private fun MoveHistory(moves: List<String>, modifier: Modifier = Modifier) {
             .verticalScroll(rememberScrollState())
             .padding(vertical = 6.dp)
     )
+}
+
+private val coachLineHeight = 34.dp
+
+/**
+ * The live coach readout: last move's grade (with an undo nudge on a
+ * blunder) and the player's current winning chances. Null when there's
+ * nothing to show (Rated mode, or nothing graded/analyzed yet).
+ */
+private fun coachStatusLine(state: GameUiState): String? {
+    val parts = mutableListOf<String>()
+    state.lastMoveRating?.let { rating ->
+        val label = when (rating) {
+            MoveClassification.BEST -> "Best move!"
+            MoveClassification.GOOD -> "Good move"
+            MoveClassification.INACCURACY -> "Inaccuracy"
+            MoveClassification.MISTAKE -> "Mistake"
+            MoveClassification.BLUNDER -> "Blunder"
+        }
+        parts += if (state.coachWarning) "$label — consider Undo" else label
+    }
+    state.winPercent?.let { parts += "Win $it%" }
+    return if (parts.isEmpty()) null else parts.joinToString("  ·  ")
 }
 
 private fun findKingSquare(squares: List<Char?>, playerColor: PlayerColor): Int? {

--- a/app/src/main/java/com/raichess/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.sp
 import com.raichess.domain.model.GameMode
 import com.raichess.domain.model.MaterialCalculator
 import com.raichess.domain.model.PlayerColor
+import com.raichess.domain.usecase.HintAdvisor
 import com.raichess.ui.theme.ChessColors
 import kotlin.math.roundToInt
 
@@ -142,7 +143,7 @@ fun GameScreen(
                         enabled = state.canHint &&
                             state.isPlayerTurn &&
                             !state.isAiThinking &&
-                            state.hintLevel < 3
+                            state.hintLevel < HintAdvisor.MAX_LEVEL
                     ) {
                         Text(if (state.hintCount > 0) "Hint (${state.hintCount})" else "Hint")
                     }

--- a/app/src/main/java/com/raichess/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameScreen.kt
@@ -471,7 +471,9 @@ private fun MoveHistory(moves: List<String>, modifier: Modifier = Modifier) {
     )
 }
 
-private val coachLineHeight = 34.dp
+// Fits maxLines = 2 of bodyMedium (20sp line height ≈ 40dp) with headroom —
+// a fixed slot shorter than its own text would overflow into the row below
+private val coachLineHeight = 42.dp
 
 /**
  * The live coach readout: last move's grade (with an undo nudge on a

--- a/app/src/main/java/com/raichess/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameScreen.kt
@@ -56,6 +56,7 @@ fun GameScreen(
     state: GameUiState,
     onSquareTapped: (Int) -> Unit,
     onUndo: () -> Unit,
+    onHint: () -> Unit,
     onResign: () -> Unit,
     onNewGame: () -> Unit
 ) {
@@ -91,6 +92,23 @@ fun GameScreen(
             modifier = Modifier.padding(vertical = 6.dp)
         )
 
+        // Coach line: a hint the player asked for, or a passive warning
+        // that the last move lost serious ground (Training mode only)
+        val coachText = state.hintText?.let { "Hint: $it" }
+            ?: if (state.coachWarning) {
+                "Coach: that last move may have lost ground — consider Undo."
+            } else {
+                null
+            }
+        if (coachText != null) {
+            Text(
+                text = coachText,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+        }
+
         CapturedRow(pieces = opponentCaptures, advantage = -playerDiff)
 
         AnimatedChessBoard(
@@ -118,6 +136,15 @@ fun GameScreen(
                 if (state.gameMode == GameMode.TRAINING) {
                     OutlinedButton(onClick = onUndo, enabled = state.canUndo) {
                         Text(if (state.undoCount > 0) "Undo (${state.undoCount})" else "Undo")
+                    }
+                    OutlinedButton(
+                        onClick = onHint,
+                        enabled = state.canHint &&
+                            state.isPlayerTurn &&
+                            !state.isAiThinking &&
+                            state.hintLevel < 3
+                    ) {
+                        Text(if (state.hintCount > 0) "Hint (${state.hintCount})" else "Hint")
                     }
                 }
                 OutlinedButton(onClick = onResign) {
@@ -192,6 +219,7 @@ private fun AnimatedChessBoard(
             squares = state.squares,
             selectedSquare = state.selectedSquare,
             legalTargets = state.legalTargets,
+            hintHighlights = state.hintHighlights,
             lastMove = state.lastMove,
             lastMoveByOpponent = state.lastMoveByOpponent,
             checkedKingSquare = if (state.isPlayerInCheck) {
@@ -231,6 +259,7 @@ fun ChessBoard(
     squares: List<Char?>,
     selectedSquare: Int?,
     legalTargets: Set<Int>,
+    hintHighlights: Set<Int> = emptySet(),
     lastMove: LastMove?,
     lastMoveByOpponent: Boolean,
     checkedKingSquare: Int?,
@@ -262,6 +291,7 @@ fun ChessBoard(
                         isCaptureTarget = index in legalTargets && squares.getOrNull(index) != null,
                         isLastMove = onLastMove,
                         isOpponentLastMove = onLastMove && lastMoveByOpponent,
+                        isHintHighlight = index in hintHighlights,
                         isCheckedKing = index == checkedKingSquare,
                         fileLabel = if (isBottomRow) ('a' + file) else null,
                         rankLabel = if (isLeftColumn) ('1' + rank) else null,
@@ -285,6 +315,7 @@ private fun BoardSquare(
     isCaptureTarget: Boolean,
     isLastMove: Boolean,
     isOpponentLastMove: Boolean,
+    isHintHighlight: Boolean,
     isCheckedKing: Boolean,
     fileLabel: Char?,
     rankLabel: Char?,
@@ -328,6 +359,13 @@ private fun BoardSquare(
                 modifier = Modifier
                     .fillMaxSize()
                     .border(2.5.dp, labelColor)
+            )
+        }
+        if (isHintHighlight) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .border(2.5.dp, ChessColors.LegalMoveIndicator)
             )
         }
         rankLabel?.let {

--- a/app/src/main/java/com/raichess/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameScreen.kt
@@ -96,10 +96,11 @@ fun GameScreen(
             modifier = Modifier.padding(vertical = 6.dp)
         )
 
-        // Coach line (Training): a requested hint, else the live move
+        // Coach line (Training only — Rated shouldn't pay a blank gap for a
+        // feature it never shows): a requested hint, else the live move
         // rating and win chances. Fixed-height slot so the board never
         // reflows when text appears or disappears.
-        Box(
+        if (state.gameMode == GameMode.TRAINING) Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(coachLineHeight),

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -87,6 +87,8 @@ data class GameUiState(
     val hintCount: Int = 0,
     /** True when the player's last move lost blunder-level ground (Training). */
     val coachWarning: Boolean = false,
+    /** True while a rung-3 deep-hint search is in flight (blocks board input). */
+    val isDeepHintRunning: Boolean = false,
     /** Live grade of the player's last move (Training; null until graded). */
     val lastMoveRating: MoveClassification? = null,
     /** Player's live winning chances 0–100 (Training; null until analyzed). */
@@ -228,6 +230,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             hintHighlights = emptySet(),
             hintCount = 0,
             coachWarning = false,
+            isDeepHintRunning = false,
             lastMoveRating = null,
             winPercent = null
         )
@@ -285,35 +288,50 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         val coach = analysisEngine ?: return
         val currentGameId = gameId
         val positionFen = cached.fen
-        gameHintCount++
+        // Level advances now (disables the button while searching), but the
+        // hint is only charged when it actually delivers content — matching
+        // rungs 1–2's no-charge-without-content behavior
         _uiState.value = state.copy(
             hintLevel = HintAdvisor.DEEP_LEVEL,
             hintText = "Thinking deeper…",
-            hintCount = gameHintCount
+            isDeepHintRunning = true
         )
         viewModelScope.launch {
-            val deep = withContext(Dispatchers.Default) {
-                engineLock.withLock {
-                    coach.analyze(Board().apply { loadFromFen(positionFen) }, DEEP_HINT_ANALYZE_MS)
+            try {
+                val deep = withContext(Dispatchers.Default) {
+                    engineLock.withLock {
+                        coach.analyze(
+                            Board().apply { loadFromFen(positionFen) },
+                            DEEP_HINT_ANALYZE_MS
+                        )
+                    }
                 }
+                if (gameId != currentGameId ||
+                    _uiState.value.phase != GamePhase.PLAYING ||
+                    board.fen != positionFen
+                ) {
+                    return@launch
+                }
+                val hint = deep?.let { HintAdvisor.hint(HintAdvisor.DEEP_LEVEL, it, positionFen) }
+                if (deep == null || hint == null) {
+                    // Refund: step back to rung 2 so the tap can be retried
+                    _uiState.value = _uiState.value.copy(
+                        hintLevel = HintAdvisor.DEEP_LEVEL - 1,
+                        hintText = "No deeper line found — try again."
+                    )
+                    return@launch
+                }
+                currentAnalysis = CachedAnalysis(positionFen, deep)
+                gameHintCount++
+                _uiState.value = _uiState.value.copy(
+                    hintText = hint.text,
+                    hintHighlights = hint.highlights,
+                    hintCount = gameHintCount,
+                    winPercent = WinProbability.percent(deep.effectiveCp())
+                )
+            } finally {
+                _uiState.value = _uiState.value.copy(isDeepHintRunning = false)
             }
-            if (gameId != currentGameId ||
-                _uiState.value.phase != GamePhase.PLAYING ||
-                board.fen != positionFen
-            ) {
-                return@launch
-            }
-            if (deep == null) {
-                _uiState.value = _uiState.value.copy(hintText = "No deeper line found.")
-                return@launch
-            }
-            currentAnalysis = CachedAnalysis(positionFen, deep)
-            val hint = HintAdvisor.hint(HintAdvisor.DEEP_LEVEL, deep, positionFen) ?: return@launch
-            _uiState.value = _uiState.value.copy(
-                hintText = hint.text,
-                hintHighlights = hint.highlights,
-                winPercent = WinProbability.percent(deep.effectiveCp())
-            )
         }
     }
 
@@ -352,6 +370,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     fun onSquareTapped(index: Int) {
         val state = _uiState.value
         if (state.phase != GamePhase.PLAYING || !state.isPlayerTurn || state.isAiThinking) return
+        // Moving mid-deep-hint would waste the requested search and queue
+        // the AI's reply behind it on the engine lock — hold input briefly
+        if (state.isDeepHintRunning) return
 
         val selected = state.selectedSquare
         if (selected != null && index in state.legalTargets) {

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -107,6 +107,17 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     private var board = Board()
     private var moveList = MoveList()
     private var engine: ChessEngine? = null
+
+    /**
+     * The engine hints/coaching analyze with. In the Stockfish opponent
+     * band this is the same instance as [engine] (its analyze() lifts the
+     * skill cap). In the RaiEngine band a dedicated full-strength Stockfish
+     * analyzer is created instead, so hints are always Stockfish-quality
+     * when the WASM bridge works — still one WebView per game, since
+     * RaiEngine opponents don't have one. Rated mode never analyzes, so it
+     * shares [engine] (unused).
+     */
+    private var analysisEngine: ChessEngine? = null
     private var gameRecorded = false
     private var gameId = 0
     private var gameUndoCount = 0
@@ -172,11 +183,21 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         // never touch the live board even if it is still running
         board = Board()
         moveList = MoveList()
-        // Release the previous game's engine (may hold a WebView) and pick the
-        // engine for this opponent strength (RaiEngine weak band / Stockfish above)
+        // Release the previous game's engines (may hold a WebView) and pick
+        // the engine for this opponent strength (RaiEngine weak band /
+        // Stockfish above)
+        if (analysisEngine !== engine) analysisEngine?.close()
         engine?.close()
         val newEngine = EngineFactory.create(getApplication<Application>(), state.opponentElo)
         engine = newEngine
+        analysisEngine = if (
+            state.gameMode == GameMode.TRAINING &&
+            !EngineFactory.usesStockfish(state.opponentElo)
+        ) {
+            EngineFactory.createAnalyzer(getApplication<Application>())
+        } else {
+            newEngine
+        }
         gameRecorded = false
         gameId++
         gameUndoCount = 0
@@ -241,6 +262,10 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         // different position than the one on screen
         val cached = currentAnalysis?.takeIf { it.fen == board.fen } ?: return
         val nextLevel = state.hintLevel + 1
+        if (nextLevel == HintAdvisor.DEEP_LEVEL) {
+            requestDeepHint(state, cached)
+            return
+        }
         val hint = HintAdvisor.hint(nextLevel, cached.analysis, cached.fen) ?: return
         gameHintCount++
         _uiState.value = state.copy(
@@ -252,6 +277,47 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
+     * Rung 3: a fresh, much deeper search (not the cached ~200ms baseline),
+     * shown when it lands. The deeper analysis also replaces the baseline,
+     * so the move played afterwards is graded against the better eval.
+     */
+    private fun requestDeepHint(state: GameUiState, cached: CachedAnalysis) {
+        val coach = analysisEngine ?: return
+        val currentGameId = gameId
+        val positionFen = cached.fen
+        gameHintCount++
+        _uiState.value = state.copy(
+            hintLevel = HintAdvisor.DEEP_LEVEL,
+            hintText = "Thinking deeper…",
+            hintCount = gameHintCount
+        )
+        viewModelScope.launch {
+            val deep = withContext(Dispatchers.Default) {
+                engineLock.withLock {
+                    coach.analyze(Board().apply { loadFromFen(positionFen) }, DEEP_HINT_ANALYZE_MS)
+                }
+            }
+            if (gameId != currentGameId ||
+                _uiState.value.phase != GamePhase.PLAYING ||
+                board.fen != positionFen
+            ) {
+                return@launch
+            }
+            if (deep == null) {
+                _uiState.value = _uiState.value.copy(hintText = "No deeper line found.")
+                return@launch
+            }
+            currentAnalysis = CachedAnalysis(positionFen, deep)
+            val hint = HintAdvisor.hint(HintAdvisor.DEEP_LEVEL, deep, positionFen) ?: return@launch
+            _uiState.value = _uiState.value.copy(
+                hintText = hint.text,
+                hintHighlights = hint.highlights,
+                winPercent = WinProbability.percent(deep.effectiveCp())
+            )
+        }
+    }
+
+    /**
      * Analyze the current position in the background (Training only) so a
      * hint is instant when asked for and the coach can measure the player's
      * next move against an honest baseline.
@@ -259,14 +325,14 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     private fun refreshBaseline() {
         val state = _uiState.value
         if (state.gameMode != GameMode.TRAINING || state.phase != GamePhase.PLAYING) return
-        val currentEngine = engine ?: return
+        val coach = analysisEngine ?: return
         val currentGameId = gameId
         val positionFen = board.fen
         viewModelScope.launch {
             val analysis = withContext(Dispatchers.Default) {
                 engineLock.withLock {
                     val analysisBoard = Board().apply { loadFromFen(positionFen) }
-                    currentEngine.analyze(analysisBoard, COACH_ANALYZE_MS)
+                    coach.analyze(analysisBoard, COACH_ANALYZE_MS)
                 }
             }
             if (gameId != currentGameId || _uiState.value.phase != GamePhase.PLAYING) return@launch
@@ -386,6 +452,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     override fun onCleared() {
+        if (analysisEngine !== engine) analysisEngine?.close()
         engine?.close()
         super.onCleared()
     }
@@ -414,6 +481,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         playerMoveLan: String? = null
     ) {
         val currentEngine = engine ?: return
+        val coach = analysisEngine
         val currentGameId = gameId
         // Snapshot the position so the background search never touches the
         // live board (resign/new-game can mutate it mid-search otherwise)
@@ -449,8 +517,8 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                     // background analysis (move 1, or right after an undo):
                     // that move silently skips grading — an accepted gap,
                     // preferable to blocking input on the coach
-                    if (coaching && baseline != null) {
-                        val afterMove = currentEngine.analyze(searchBoard, COACH_ANALYZE_MS)
+                    if (coaching && baseline != null && coach != null) {
+                        val afterMove = coach.analyze(searchBoard, COACH_ANALYZE_MS)
                         if (afterMove != null) {
                             playerMoveLoss = MoveClassifier.lossBetween(baseline, afterMove)
                             playerMoveRating = MoveClassifier.classify(
@@ -690,5 +758,10 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         // pause, and the new-position baseline runs after turn handoff —
         // neither delays the player's control of the board.
         private const val COACH_ANALYZE_MS = 200L
+
+        // The third hint tap's search budget: long enough for a genuinely
+        // deeper verdict, short enough to feel like a considered answer
+        // rather than a stall.
+        private const val DEEP_HINT_ANALYZE_MS = 1500L
     }
 }

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -1,7 +1,6 @@
 package com.raichess.ui.game
 
 import android.app.Application
-import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.bhlangonijr.chesslib.Board
@@ -17,7 +16,6 @@ import com.raichess.data.analysis.AnalysisCoordinator
 import com.raichess.data.engine.ChessEngine
 import com.raichess.data.engine.EngineFactory
 import com.raichess.data.engine.RaiEngine
-import com.raichess.data.repository.GameRepository
 import com.raichess.data.repository.PlayerProfileRepository
 import com.raichess.data.repository.PracticeRepository
 import com.raichess.data.repository.SettingsRepository
@@ -26,12 +24,13 @@ import com.raichess.domain.model.EloConfiguration
 import com.raichess.domain.model.EloStats
 import com.raichess.domain.model.GameMode
 import com.raichess.domain.model.GameResult
+import com.raichess.domain.model.MoveClassification
 import com.raichess.domain.model.MoveClassifier
 import com.raichess.domain.model.PgnBuilder
 import com.raichess.domain.model.PlayerColor
 import com.raichess.domain.model.PositionAnalysis
-import com.raichess.domain.model.ThemeTag
 import com.raichess.domain.model.UndoPenalty
+import com.raichess.domain.model.WinProbability
 import com.raichess.domain.model.canUndo
 import com.raichess.domain.usecase.HintAdvisor
 import kotlinx.coroutines.Dispatchers
@@ -88,6 +87,10 @@ data class GameUiState(
     val hintCount: Int = 0,
     /** True when the player's last move lost blunder-level ground (Training). */
     val coachWarning: Boolean = false,
+    /** Live grade of the player's last move (Training; null until graded). */
+    val lastMoveRating: MoveClassification? = null,
+    /** Player's live winning chances 0–100 (Training; null until analyzed). */
+    val winPercent: Int? = null,
     val moveHistorySan: List<String> = emptyList(),
     val isPlayerTurn: Boolean = false,
     val isAiThinking: Boolean = false,
@@ -101,7 +104,6 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     private val repository = PlayerProfileRepository(application)
     private val practiceRepository = PracticeRepository(application)
     private val settingsRepository = SettingsRepository(application)
-    private val gameRepository = GameRepository(application)
     private var board = Board()
     private var moveList = MoveList()
     private var engine: ChessEngine? = null
@@ -124,8 +126,6 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     /** Analysis of the position the player is currently looking at (Training). */
     private var currentAnalysis: CachedAnalysis? = null
-    /** The player's worst substantive weakness, for personalized rung-1 hints. */
-    private var topWeakness: ThemeTag? = null
 
     private val _uiState = MutableStateFlow(
         repository.getStats().let { stats ->
@@ -182,17 +182,6 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         gameUndoCount = 0
         gameHintCount = 0
         currentAnalysis = null
-        // Refresh the weakness profile once per game for personalized hints
-        viewModelScope.launch {
-            topWeakness = try {
-                gameRepository.weaknessProfile().weaknesses.firstOrNull()?.theme
-            } catch (e: Exception) {
-                // Hints degrade to generic nudges; log so a broken profile
-                // fetch isn't invisible when debugging personalization
-                Log.w(TAG, "weakness profile unavailable", e)
-                null
-            }
-        }
 
         _uiState.value = state.copy(
             phase = GamePhase.PLAYING,
@@ -217,7 +206,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             hintText = null,
             hintHighlights = emptySet(),
             hintCount = 0,
-            coachWarning = false
+            coachWarning = false,
+            lastMoveRating = null,
+            winPercent = null
         )
 
         if (color == PlayerColor.BLACK) {
@@ -250,7 +241,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         // different position than the one on screen
         val cached = currentAnalysis?.takeIf { it.fen == board.fen } ?: return
         val nextLevel = state.hintLevel + 1
-        val hint = HintAdvisor.hint(nextLevel, cached.analysis, state.squares, topWeakness) ?: return
+        val hint = HintAdvisor.hint(nextLevel, cached.analysis, cached.fen) ?: return
         gameHintCount++
         _uiState.value = state.copy(
             hintLevel = nextLevel,
@@ -283,7 +274,12 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             // refreshBaseline for the newer position will supply the cache
             if (analysis == null || board.fen != positionFen) return@launch
             currentAnalysis = CachedAnalysis(positionFen, analysis)
-            _uiState.value = _uiState.value.copy(canHint = _uiState.value.isPlayerTurn)
+            _uiState.value = _uiState.value.copy(
+                canHint = _uiState.value.isPlayerTurn,
+                // Baseline positions are player-to-move, so effectiveCp is
+                // already the player's perspective
+                winPercent = WinProbability.percent(analysis.effectiveCp())
+            )
         }
     }
 
@@ -373,7 +369,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             hintLevel = 0,
             hintText = null,
             hintHighlights = emptySet(),
-            coachWarning = false
+            coachWarning = false,
+            lastMoveRating = null,
+            winPercent = null
             // moveSeq deliberately not incremented: undo never animates
         )
         currentAnalysis = null
@@ -397,16 +395,24 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         val fenBeforeMove = board.fen
         applyMove(move)
         if (!checkGameOver()) {
-            makeAiMove(playerMoveBaselineFen = fenBeforeMove)
+            makeAiMove(
+                playerMoveBaselineFen = fenBeforeMove,
+                playerMoveLan = move.toString().lowercase()
+            )
         }
     }
 
     /**
      * @param playerMoveBaselineFen the position the player just moved from,
-     *   for blunder grading — null when there is no player move to grade
+     *   for move grading — null when there is no player move to grade
      *   (the AI's opening move as White)
+     * @param playerMoveLan the move the player just played, for the BEST
+     *   classification when it matches the engine's own choice
      */
-    private fun makeAiMove(playerMoveBaselineFen: String? = null) {
+    private fun makeAiMove(
+        playerMoveBaselineFen: String? = null,
+        playerMoveLan: String? = null
+    ) {
         val currentEngine = engine ?: return
         val currentGameId = gameId
         // Snapshot the position so the background search never touches the
@@ -430,6 +436,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             val startedAt = System.currentTimeMillis()
             var playerMoveLoss = 0
+            var playerMoveRating: MoveClassification? = null
             val move = withContext(Dispatchers.Default) {
                 // ChessEngine.selectMove is single-caller only (see its KDoc):
                 // never launch overlapping AI-move coroutines, or the engine's
@@ -446,6 +453,11 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                         val afterMove = currentEngine.analyze(searchBoard, COACH_ANALYZE_MS)
                         if (afterMove != null) {
                             playerMoveLoss = MoveClassifier.lossBetween(baseline, afterMove)
+                            playerMoveRating = MoveClassifier.classify(
+                                playerMoveLoss,
+                                playedEngineBest = playerMoveLan != null &&
+                                    playerMoveLan == baseline.bestMoveLan
+                            )
                         }
                     }
                     currentEngine.selectMove(searchBoard)
@@ -474,6 +486,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                     // the practice position) is the recovery path
                     coachWarning = coaching &&
                         playerMoveLoss >= MoveClassifier.BLUNDER_THRESHOLD_CP,
+                    lastMoveRating = playerMoveRating,
                     canUndo = canUndo(
                         mode = current.gameMode,
                         isPlaying = true,
@@ -507,11 +520,12 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             isPlayerInCheck = isPlayerInCheck(),
             moveSeq = state.moveSeq + 1,
             canUndo = false, // re-enabled when the turn returns to the player
-            // Any move invalidates the current hint and coach warning
+            // Any move invalidates the current hint, warning, and grade
             hintLevel = 0,
             hintText = null,
             hintHighlights = emptySet(),
-            coachWarning = false
+            coachWarning = false,
+            lastMoveRating = null
         )
     }
 
@@ -669,7 +683,6 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     companion object {
-        private const val TAG = "GameViewModel"
         private const val MIN_AI_MOVE_DELAY_MS = 350L
 
         // Coach/hint search budget per position. Two run per full move in

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -332,17 +332,22 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                     winPercent = WinProbability.percent(deep.effectiveCp())
                 )
             } finally {
-                val current = _uiState.value
-                _uiState.value = current.copy(
-                    isDeepHintRunning = false,
-                    canUndo = canUndo(
-                        mode = current.gameMode,
-                        isPlaying = current.phase == GamePhase.PLAYING,
-                        isPlayerTurn = current.isPlayerTurn,
-                        isAiThinking = current.isAiThinking,
-                        moveCount = moveList.size
+                // Same staleness discipline as every other async write: a
+                // new game already reset these fields in startGame, so a
+                // stale coroutine must not touch the new game's state
+                if (gameId == currentGameId) {
+                    val current = _uiState.value
+                    _uiState.value = current.copy(
+                        isDeepHintRunning = false,
+                        canUndo = canUndo(
+                            mode = current.gameMode,
+                            isPlaying = current.phase == GamePhase.PLAYING,
+                            isPlayerTurn = current.isPlayerTurn,
+                            isAiThinking = current.isAiThinking,
+                            moveCount = moveList.size
+                        )
                     )
-                )
+                }
             }
         }
     }

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -16,6 +16,7 @@ import com.raichess.data.analysis.AnalysisCoordinator
 import com.raichess.data.engine.ChessEngine
 import com.raichess.data.engine.EngineFactory
 import com.raichess.data.engine.RaiEngine
+import com.raichess.data.repository.GameRepository
 import com.raichess.data.repository.PlayerProfileRepository
 import com.raichess.data.repository.PracticeRepository
 import com.raichess.data.repository.SettingsRepository
@@ -24,16 +25,22 @@ import com.raichess.domain.model.EloConfiguration
 import com.raichess.domain.model.EloStats
 import com.raichess.domain.model.GameMode
 import com.raichess.domain.model.GameResult
+import com.raichess.domain.model.MoveClassifier
 import com.raichess.domain.model.PgnBuilder
 import com.raichess.domain.model.PlayerColor
+import com.raichess.domain.model.PositionAnalysis
+import com.raichess.domain.model.ThemeTag
 import com.raichess.domain.model.UndoPenalty
 import com.raichess.domain.model.canUndo
+import com.raichess.domain.usecase.HintAdvisor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.random.Random
 
@@ -69,6 +76,17 @@ data class GameUiState(
     val lastMoveByOpponent: Boolean = false,
     /** Label of the engine actually playing ("RaiEngine" / "Stockfish" / fallback). */
     val engineLabel: String = "RaiEngine",
+    /** True when a hint could be offered (Training + a fresh analysis is cached). */
+    val canHint: Boolean = false,
+    /** Rung of the hint ladder revealed for the current position (0 = none). */
+    val hintLevel: Int = 0,
+    val hintText: String? = null,
+    /** Squares highlighted by the current hint (a1=0 .. h8=63). */
+    val hintHighlights: Set<Int> = emptySet(),
+    /** Hints used this game (Training only; docks accuracy like undos). */
+    val hintCount: Int = 0,
+    /** True when the player's last move lost blunder-level ground (Training). */
+    val coachWarning: Boolean = false,
     val moveHistorySan: List<String> = emptyList(),
     val isPlayerTurn: Boolean = false,
     val isAiThinking: Boolean = false,
@@ -82,12 +100,23 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     private val repository = PlayerProfileRepository(application)
     private val practiceRepository = PracticeRepository(application)
     private val settingsRepository = SettingsRepository(application)
+    private val gameRepository = GameRepository(application)
     private var board = Board()
     private var moveList = MoveList()
     private var engine: ChessEngine? = null
     private var gameRecorded = false
     private var gameId = 0
     private var gameUndoCount = 0
+    private var gameHintCount = 0
+
+    // Serializes every engine call (analyze + selectMove): ChessEngine is
+    // single-caller, and coaching adds analyze() calls that could otherwise
+    // overlap a search (e.g. an undo's baseline refresh racing the next AI move)
+    private val engineLock = Mutex()
+    /** Analysis of the position the player is currently looking at (Training). */
+    private var currentAnalysis: PositionAnalysis? = null
+    /** The player's worst substantive weakness, for personalized rung-1 hints. */
+    private var topWeakness: ThemeTag? = null
 
     private val _uiState = MutableStateFlow(
         repository.getStats().let { stats ->
@@ -142,6 +171,16 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         gameRecorded = false
         gameId++
         gameUndoCount = 0
+        gameHintCount = 0
+        currentAnalysis = null
+        // Refresh the weakness profile once per game for personalized hints
+        viewModelScope.launch {
+            topWeakness = try {
+                gameRepository.weaknessProfile().weaknesses.firstOrNull()?.theme
+            } catch (e: Exception) {
+                null
+            }
+        }
 
         _uiState.value = state.copy(
             phase = GamePhase.PLAYING,
@@ -160,11 +199,75 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             eloDelta = null,
             undoCount = 0,
             canUndo = false,
-            moveSeq = 0
+            moveSeq = 0,
+            canHint = false,
+            hintLevel = 0,
+            hintText = null,
+            hintHighlights = emptySet(),
+            hintCount = 0,
+            coachWarning = false
         )
 
         if (color == PlayerColor.BLACK) {
             makeAiMove()
+        } else {
+            // Playing White: seed the coach/hint baseline for move one
+            refreshBaseline()
+        }
+    }
+
+    /**
+     * Progressive hint (Training only): each tap reveals the next rung of
+     * [HintAdvisor]'s ladder for the current position. Costs accuracy like
+     * an undo — assistance shouldn't be free, or the incentive design of
+     * Training mode collapses. No engine call: reuses the baseline analysis
+     * the coach already computed for this position.
+     */
+    fun requestHint() {
+        val state = _uiState.value
+        if (state.gameMode != GameMode.TRAINING ||
+            state.phase != GamePhase.PLAYING ||
+            !state.isPlayerTurn ||
+            state.isAiThinking ||
+            state.hintLevel >= HintAdvisor.MAX_LEVEL
+        ) {
+            return
+        }
+        val analysis = currentAnalysis ?: return
+        val nextLevel = state.hintLevel + 1
+        val hint = HintAdvisor.hint(nextLevel, analysis, state.squares, topWeakness) ?: return
+        gameHintCount++
+        _uiState.value = state.copy(
+            hintLevel = nextLevel,
+            hintText = hint.text,
+            hintHighlights = hint.highlights,
+            hintCount = gameHintCount
+        )
+    }
+
+    /**
+     * Analyze the current position in the background (Training only) so a
+     * hint is instant when asked for and the coach can measure the player's
+     * next move against an honest baseline.
+     */
+    private fun refreshBaseline() {
+        val state = _uiState.value
+        if (state.gameMode != GameMode.TRAINING || state.phase != GamePhase.PLAYING) return
+        val currentEngine = engine ?: return
+        val currentGameId = gameId
+        val positionFen = board.fen
+        viewModelScope.launch {
+            val analysis = withContext(Dispatchers.Default) {
+                engineLock.withLock {
+                    val analysisBoard = Board().apply { loadFromFen(positionFen) }
+                    currentEngine.analyze(analysisBoard, COACH_ANALYZE_MS)
+                }
+            }
+            if (gameId != currentGameId || _uiState.value.phase != GamePhase.PLAYING) return@launch
+            currentAnalysis = analysis
+            _uiState.value = _uiState.value.copy(
+                canHint = analysis != null && _uiState.value.isPlayerTurn
+            )
         }
     }
 
@@ -247,9 +350,18 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                 isPlayerTurn = true,
                 isAiThinking = false,
                 moveCount = remaining.size
-            )
+            ),
+            // The rolled-back position needs a fresh baseline before hints
+            // or coaching resume
+            canHint = false,
+            hintLevel = 0,
+            hintText = null,
+            hintHighlights = emptySet(),
+            coachWarning = false
             // moveSeq deliberately not incremented: undo never animates
         )
+        currentAnalysis = null
+        refreshBaseline()
     }
 
     fun backToSetup() {
@@ -278,17 +390,42 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         // Snapshot the position so the background search never touches the
         // live board (resign/new-game can mutate it mid-search otherwise)
         val positionFen = board.fen
-        _uiState.value = _uiState.value.copy(isAiThinking = true, isPlayerTurn = false)
+        val coaching = _uiState.value.gameMode == GameMode.TRAINING
+        // Eval of the position before the player's last move, if the coach
+        // had time to compute one — the reference for blunder detection
+        val baseline = currentAnalysis
+        currentAnalysis = null
+        _uiState.value = _uiState.value.copy(
+            isAiThinking = true,
+            isPlayerTurn = false,
+            canHint = false
+        )
 
         viewModelScope.launch {
             val startedAt = System.currentTimeMillis()
+            var playerMoveLoss = 0
             val move = withContext(Dispatchers.Default) {
                 // ChessEngine.selectMove is single-caller only (see its KDoc):
                 // never launch overlapping AI-move coroutines, or the engine's
                 // shared UCI queue would be raced. The isAiThinking gate on
-                // player input keeps this to one in-flight search at a time.
-                val searchBoard = Board().apply { loadFromFen(positionFen) }
-                currentEngine.selectMove(searchBoard)
+                // player input plus engineLock keep this to one in-flight
+                // engine call at a time.
+                engineLock.withLock {
+                    val searchBoard = Board().apply { loadFromFen(positionFen) }
+                    if (coaching && baseline != null) {
+                        // Grade the player's move live: the eval swing between
+                        // the pre-move baseline and this position, both from
+                        // the player's perspective
+                        val afterMove = currentEngine.analyze(searchBoard, COACH_ANALYZE_MS)
+                        if (afterMove != null) {
+                            playerMoveLoss = MoveClassifier.centipawnLoss(
+                                baseline.effectiveCp(),
+                                -afterMove.effectiveCp()
+                            )
+                        }
+                    }
+                    currentEngine.selectMove(searchBoard)
+                }
             }
             // Pause so instant replies still read as a "thinking" opponent,
             // as a floor on total time rather than an added delay
@@ -300,12 +437,37 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                 applyMove(move)
             }
             if (!checkGameOver()) {
+                // Baseline for the player's new position: powers instant
+                // hints and the next blunder check
+                val newBaseline = if (coaching) {
+                    val fenNow = board.fen
+                    withContext(Dispatchers.Default) {
+                        engineLock.withLock {
+                            currentEngine.analyze(
+                                Board().apply { loadFromFen(fenNow) },
+                                COACH_ANALYZE_MS
+                            )
+                        }
+                    }
+                } else {
+                    null
+                }
+                if (_uiState.value.phase != GamePhase.PLAYING || gameId != currentGameId) {
+                    return@launch
+                }
+                currentAnalysis = newBaseline
                 val current = _uiState.value
                 _uiState.value = current.copy(
                     isAiThinking = false,
                     isPlayerTurn = true,
                     // Reflect a mid-game Stockfish->RaiEngine fallback in the label
                     engineLabel = currentEngine.activeEngineLabel,
+                    canHint = newBaseline != null,
+                    // Passive nudge, not an interrupt: the AI has already
+                    // replied, and the existing Training undo (which records
+                    // the practice position) is the recovery path
+                    coachWarning = coaching &&
+                        playerMoveLoss >= MoveClassifier.BLUNDER_THRESHOLD_CP,
                     canUndo = canUndo(
                         mode = current.gameMode,
                         isPlaying = true,
@@ -334,7 +496,12 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             moveHistorySan = sanHistory(),
             isPlayerInCheck = isPlayerInCheck(),
             moveSeq = state.moveSeq + 1,
-            canUndo = false // re-enabled when the turn returns to the player
+            canUndo = false, // re-enabled when the turn returns to the player
+            // Any move invalidates the current hint and coach warning
+            hintLevel = 0,
+            hintText = null,
+            hintHighlights = emptySet(),
+            coachWarning = false
         )
     }
 
@@ -364,9 +531,11 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         if (gameRecorded) return
         gameRecorded = true
         val state = _uiState.value
-        // Training-mode undos dock the accuracy input; Rated stays neutral
+        // Training-mode assistance docks the accuracy input; Rated stays
+        // neutral. Hints count like undos: each rung revealed is help the
+        // player asked for.
         val accuracy = if (state.gameMode == GameMode.TRAINING) {
-            UndoPenalty.accuracyAfterUndos(gameUndoCount)
+            UndoPenalty.accuracyAfterUndos(gameUndoCount + gameHintCount)
         } else {
             UndoPenalty.NEUTRAL_ACCURACY
         }
@@ -491,5 +660,10 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     companion object {
         private const val MIN_AI_MOVE_DELAY_MS = 350L
+
+        // Coach/hint search budget per position. Two of these run per full
+        // move in Training (grade the player's move + baseline the new
+        // position); short enough to hide inside the AI-thinking pause.
+        private const val COACH_ANALYZE_MS = 200L
     }
 }

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -416,16 +416,14 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                 // engine call at a time.
                 engineLock.withLock {
                     val searchBoard = Board().apply { loadFromFen(positionFen) }
+                    // baseline is null when the player outraced the ~200ms
+                    // background analysis (move 1, or right after an undo):
+                    // that move silently skips grading — an accepted gap,
+                    // preferable to blocking input on the coach
                     if (coaching && baseline != null) {
-                        // Grade the player's move live: the eval swing between
-                        // the pre-move baseline and this position, both from
-                        // the player's perspective
                         val afterMove = currentEngine.analyze(searchBoard, COACH_ANALYZE_MS)
                         if (afterMove != null) {
-                            playerMoveLoss = MoveClassifier.centipawnLoss(
-                                baseline.effectiveCp(),
-                                -afterMove.effectiveCp()
-                            )
+                            playerMoveLoss = MoveClassifier.lossBetween(baseline, afterMove)
                         }
                     }
                     currentEngine.selectMove(searchBoard)

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -114,8 +114,16 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     // single-caller, and coaching adds analyze() calls that could otherwise
     // overlap a search (e.g. an undo's baseline refresh racing the next AI move)
     private val engineLock = Mutex()
+
+    /**
+     * A coach analysis tagged with the position it was computed for, so a
+     * slow background analysis resolving after a fast player move can never
+     * be applied to the wrong position — every consumer validates the FEN.
+     */
+    private data class CachedAnalysis(val fen: String, val analysis: PositionAnalysis)
+
     /** Analysis of the position the player is currently looking at (Training). */
-    private var currentAnalysis: PositionAnalysis? = null
+    private var currentAnalysis: CachedAnalysis? = null
     /** The player's worst substantive weakness, for personalized rung-1 hints. */
     private var topWeakness: ThemeTag? = null
 
@@ -231,15 +239,18 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         val state = _uiState.value
         if (state.gameMode != GameMode.TRAINING ||
             state.phase != GamePhase.PLAYING ||
+            !state.canHint ||
             !state.isPlayerTurn ||
             state.isAiThinking ||
             state.hintLevel >= HintAdvisor.MAX_LEVEL
         ) {
             return
         }
-        val analysis = currentAnalysis ?: return
+        // Defense in depth beyond canHint: never hint from an analysis of a
+        // different position than the one on screen
+        val cached = currentAnalysis?.takeIf { it.fen == board.fen } ?: return
         val nextLevel = state.hintLevel + 1
-        val hint = HintAdvisor.hint(nextLevel, analysis, state.squares, topWeakness) ?: return
+        val hint = HintAdvisor.hint(nextLevel, cached.analysis, state.squares, topWeakness) ?: return
         gameHintCount++
         _uiState.value = state.copy(
             hintLevel = nextLevel,
@@ -268,10 +279,11 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                 }
             }
             if (gameId != currentGameId || _uiState.value.phase != GamePhase.PLAYING) return@launch
-            currentAnalysis = analysis
-            _uiState.value = _uiState.value.copy(
-                canHint = analysis != null && _uiState.value.isPlayerTurn
-            )
+            // Discard if the board moved on while we analyzed — the newer
+            // refreshBaseline for the newer position will supply the cache
+            if (analysis == null || board.fen != positionFen) return@launch
+            currentAnalysis = CachedAnalysis(positionFen, analysis)
+            _uiState.value = _uiState.value.copy(canHint = _uiState.value.isPlayerTurn)
         }
     }
 
@@ -382,13 +394,19 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun playPlayerMove(fromIndex: Int, toIndex: Int) {
         val move = findLegalMove(fromIndex, toIndex) ?: return
+        val fenBeforeMove = board.fen
         applyMove(move)
         if (!checkGameOver()) {
-            makeAiMove()
+            makeAiMove(playerMoveBaselineFen = fenBeforeMove)
         }
     }
 
-    private fun makeAiMove() {
+    /**
+     * @param playerMoveBaselineFen the position the player just moved from,
+     *   for blunder grading — null when there is no player move to grade
+     *   (the AI's opening move as White)
+     */
+    private fun makeAiMove(playerMoveBaselineFen: String? = null) {
         val currentEngine = engine ?: return
         val currentGameId = gameId
         // Snapshot the position so the background search never touches the
@@ -396,8 +414,12 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         val positionFen = board.fen
         val coaching = _uiState.value.gameMode == GameMode.TRAINING
         // Eval of the position before the player's last move, if the coach
-        // had time to compute one — the reference for blunder detection
-        val baseline = currentAnalysis
+        // had time to compute one for exactly that position — the FEN check
+        // means a stale analysis of some earlier position can never grade
+        // this move
+        val baseline = playerMoveBaselineFen?.let { fen ->
+            currentAnalysis?.takeIf { it.fen == fen }?.analysis
+        }
         currentAnalysis = null
         _uiState.value = _uiState.value.copy(
             isAiThinking = true,

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -439,32 +439,14 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                 applyMove(move)
             }
             if (!checkGameOver()) {
-                // Baseline for the player's new position: powers instant
-                // hints and the next blunder check
-                val newBaseline = if (coaching) {
-                    val fenNow = board.fen
-                    withContext(Dispatchers.Default) {
-                        engineLock.withLock {
-                            currentEngine.analyze(
-                                Board().apply { loadFromFen(fenNow) },
-                                COACH_ANALYZE_MS
-                            )
-                        }
-                    }
-                } else {
-                    null
-                }
-                if (_uiState.value.phase != GamePhase.PLAYING || gameId != currentGameId) {
-                    return@launch
-                }
-                currentAnalysis = newBaseline
                 val current = _uiState.value
                 _uiState.value = current.copy(
                     isAiThinking = false,
                     isPlayerTurn = true,
                     // Reflect a mid-game Stockfish->RaiEngine fallback in the label
                     engineLabel = currentEngine.activeEngineLabel,
-                    canHint = newBaseline != null,
+                    // Re-enabled once the background baseline lands
+                    canHint = false,
                     // Passive nudge, not an interrupt: the AI has already
                     // replied, and the existing Training undo (which records
                     // the practice position) is the recovery path
@@ -478,6 +460,10 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                         moveCount = moveList.size
                     )
                 )
+                // Baseline for the player's new position (hints + next
+                // blunder check) catches up in the background — turn
+                // handoff must never wait on the coach
+                if (coaching) refreshBaseline()
             }
         }
     }
@@ -664,9 +650,10 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         private const val TAG = "GameViewModel"
         private const val MIN_AI_MOVE_DELAY_MS = 350L
 
-        // Coach/hint search budget per position. Two of these run per full
-        // move in Training (grade the player's move + baseline the new
-        // position); short enough to hide inside the AI-thinking pause.
+        // Coach/hint search budget per position. Two run per full move in
+        // Training: grading the player's move hides inside the AI-thinking
+        // pause, and the new-position baseline runs after turn handoff —
+        // neither delays the player's control of the board.
         private const val COACH_ANALYZE_MS = 200L
     }
 }

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -294,7 +294,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         _uiState.value = state.copy(
             hintLevel = HintAdvisor.DEEP_LEVEL,
             hintText = "Thinking deeper…",
-            isDeepHintRunning = true
+            isDeepHintRunning = true,
+            // Undo rides out the search too — greyed, not silently dead
+            canUndo = false
         )
         viewModelScope.launch {
             try {
@@ -330,7 +332,17 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                     winPercent = WinProbability.percent(deep.effectiveCp())
                 )
             } finally {
-                _uiState.value = _uiState.value.copy(isDeepHintRunning = false)
+                val current = _uiState.value
+                _uiState.value = current.copy(
+                    isDeepHintRunning = false,
+                    canUndo = canUndo(
+                        mode = current.gameMode,
+                        isPlaying = current.phase == GamePhase.PLAYING,
+                        isPlayerTurn = current.isPlayerTurn,
+                        isAiThinking = current.isAiThinking,
+                        moveCount = moveList.size
+                    )
+                )
             }
         }
     }
@@ -404,6 +416,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
      */
     fun undoMove() {
         val state = _uiState.value
+        // Ride out an in-flight deep hint (≤1.5s): undoing under it would
+        // leave input blocked on a stale search holding the engine lock
+        if (state.isDeepHintRunning) return
         if (!canUndo(
                 mode = state.gameMode,
                 isPlaying = state.phase == GamePhase.PLAYING,

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -600,9 +600,14 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                     canHint = false,
                     // Passive nudge, not an interrupt: the AI has already
                     // replied, and the existing Training undo (which records
-                    // the practice position) is the recovery path
-                    coachWarning = coaching &&
-                        playerMoveLoss >= MoveClassifier.BLUNDER_THRESHOLD_CP,
+                    // the practice position) is the recovery path. Derived
+                    // from the rating, NOT the raw eval swing: two short
+                    // searches can disagree by blunder-level noise even when
+                    // the player played the engine's own best move, and
+                    // "Best move — consider Undo" is nonsense. classify()
+                    // already resolves that (playedBest can never be BLUNDER),
+                    // so the rating is the single source of truth.
+                    coachWarning = playerMoveRating == MoveClassification.BLUNDER,
                     lastMoveRating = playerMoveRating,
                     canUndo = canUndo(
                         mode = current.gameMode,

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -1,6 +1,7 @@
 package com.raichess.ui.game
 
 import android.app.Application
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.bhlangonijr.chesslib.Board
@@ -178,6 +179,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             topWeakness = try {
                 gameRepository.weaknessProfile().weaknesses.firstOrNull()?.theme
             } catch (e: Exception) {
+                // Hints degrade to generic nudges; log so a broken profile
+                // fetch isn't invisible when debugging personalization
+                Log.w(TAG, "weakness profile unavailable", e)
                 null
             }
         }
@@ -659,6 +663,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     companion object {
+        private const val TAG = "GameViewModel"
         private const val MIN_AI_MOVE_DELAY_MS = 350L
 
         // Coach/hint search budget per position. Two of these run per full

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -576,7 +576,15 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             if (move != null) {
                 applyMove(move)
             }
-            if (!checkGameOver()) {
+            val gameEnded = checkGameOver()
+            // Publish the grade even — especially — when the reply ended the
+            // game: the move that walks into mate is the most coaching-worthy
+            // move there is. finishGame has already settled winPercent to the
+            // result and cleared the undo nudge (undo isn't available now).
+            if (gameEnded && coaching && playerMoveRating != null) {
+                _uiState.value = _uiState.value.copy(lastMoveRating = playerMoveRating)
+            }
+            if (!gameEnded) {
                 val current = _uiState.value
                 _uiState.value = current.copy(
                     isAiThinking = false,
@@ -677,8 +685,23 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             isPlayerTurn = false,
             ending = ending,
             eloDelta = delta,
-            canUndo = false
+            canUndo = false,
+            canHint = false,
+            coachWarning = false,
+            // The result settles the eval — a pre-move win% would sit stale
+            // next to the verdict on the game-over screen
+            winPercent = if (state.gameMode == GameMode.TRAINING) {
+                terminalWinPercent(ending)
+            } else {
+                null
+            }
         )
+    }
+
+    private fun terminalWinPercent(ending: GameEnding): Int = when (ending) {
+        GameEnding.CHECKMATE_WIN -> 100
+        GameEnding.CHECKMATE_LOSS, GameEnding.RESIGNED -> 0
+        GameEnding.DRAW -> 50
     }
 
     /**

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -625,6 +625,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             moveSeq = state.moveSeq + 1,
             canUndo = false, // re-enabled when the turn returns to the player
             // Any move invalidates the current hint, warning, and grade
+            canHint = false,
             hintLevel = 0,
             hintText = null,
             hintHighlights = emptySet(),
@@ -790,9 +791,11 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         private const val MIN_AI_MOVE_DELAY_MS = 350L
 
         // Coach/hint search budget per position. Two run per full move in
-        // Training: grading the player's move hides inside the AI-thinking
-        // pause, and the new-position baseline runs after turn handoff —
-        // neither delays the player's control of the board.
+        // Training: grading the player's move runs during the AI-thinking
+        // pause (fully hidden when the opponent's own search dominates; at
+        // the fastest Stockfish bands it adds up to ~200ms to the reply —
+        // an accepted cost of grading every move), and the new-position
+        // baseline runs after turn handoff. Neither blocks board input.
         private const val COACH_ANALYZE_MS = 200L
 
         // The third hint tap's search budget: long enough for a genuinely

--- a/app/src/test/java/com/raichess/domain/model/MoveClassifierTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/MoveClassifierTest.kt
@@ -45,6 +45,18 @@ class MoveClassifierTest {
     }
 
     @Test
+    fun `lossBetween flips the opponent-perspective eval back to the mover`() {
+        fun cp(score: Int) = PositionAnalysis(scoreCp = score, mateIn = null, bestMoveLan = null)
+        // +20 for the mover before; opponent sees -30 after → mover +30: no loss
+        assertEquals(0, MoveClassifier.lossBetween(cp(20), cp(-30)))
+        // -80 before; opponent then mates → mover at -1000 capped: 920 lost
+        val mated = PositionAnalysis(scoreCp = null, mateIn = 1, bestMoveLan = null)
+        assertEquals(920, MoveClassifier.lossBetween(cp(-80), mated))
+        // +200 before; opponent sees +200 after → mover -200: 400 lost
+        assertEquals(400, MoveClassifier.lossBetween(cp(200), cp(200)))
+    }
+
+    @Test
     fun `effectiveCp caps runaway and mate scores`() {
         assertEquals(40, PositionAnalysis(scoreCp = 40, mateIn = null, bestMoveLan = "e2e4").effectiveCp())
         assertEquals(1000, PositionAnalysis(scoreCp = 5200, mateIn = null, bestMoveLan = "e2e4").effectiveCp())

--- a/app/src/test/java/com/raichess/domain/model/WinProbabilityTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/WinProbabilityTest.kt
@@ -1,0 +1,33 @@
+package com.raichess.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WinProbabilityTest {
+
+    @Test
+    fun `level position is a coin flip`() {
+        assertEquals(50, WinProbability.percent(0))
+    }
+
+    @Test
+    fun `curve is symmetric around fifty`() {
+        for (cp in intArrayOf(50, 100, 300, 700, 1000)) {
+            assertEquals(100, WinProbability.percent(cp) + WinProbability.percent(-cp))
+        }
+    }
+
+    @Test
+    fun `curve is monotonic and saturates near the mate cap`() {
+        var previous = -1
+        for (cp in -1000..1000 step 100) {
+            val percent = WinProbability.percent(cp)
+            assertTrue(percent >= previous)
+            previous = percent
+        }
+        assertTrue(WinProbability.percent(1000) in 95..100)
+        assertTrue(WinProbability.percent(-1000) in 0..5)
+        assertTrue(WinProbability.percent(300) in 70..80)
+    }
+}

--- a/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
@@ -59,6 +59,14 @@ class HintAdvisorTest {
     }
 
     @Test
+    fun `an even trade does not claim to win material`() {
+        // Best move takes a queen but the eval is level — it's a trade
+        // (Qxq, recapture), not a win, so fall through to the generic nudge
+        val hint = HintAdvisor.hint(1, cp(0, "d1d8"), squares(59 to 'q'), null)!!
+        assertTrue(hint.text.contains("stronger move"))
+    }
+
+    @Test
     fun `pawn captures do not trigger the material cue`() {
         // Best move captures a pawn (100cp < the 300cp significance floor)
         val hint = HintAdvisor.hint(1, cp(80, "d4e5"), squares(36 to 'p'), null)!!

--- a/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
@@ -1,23 +1,16 @@
 package com.raichess.domain.usecase
 
 import com.raichess.domain.model.PositionAnalysis
-import com.raichess.domain.model.ThemeTag
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class HintAdvisorTest {
 
-    /** Empty board with the given (square ordinal → FEN char) placements. */
-    private fun squares(vararg placements: Pair<Int, Char>): List<Char?> {
-        val board = arrayOfNulls<Char>(64)
-        placements.forEach { (index, piece) -> board[index] = piece }
-        return board.toList()
-    }
-
     private fun cp(score: Int, best: String?) =
         PositionAnalysis(scoreCp = score, mateIn = null, bestMoveLan = best, depth = 12)
+
+    private val startFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 
     @Test
     fun `square ordinals map lan squares to a1-h8 indexing`() {
@@ -30,87 +23,44 @@ class HintAdvisorTest {
     }
 
     @Test
-    fun `level one prefers the mate cue over everything`() {
-        val analysis = PositionAnalysis(scoreCp = null, mateIn = 2, bestMoveLan = "d1h5", depth = 12)
-        val hint = HintAdvisor.hint(1, analysis, squares(), ThemeTag.HANGING_PIECE)!!
-        assertTrue(hint.text.contains("forced mate"))
-        assertTrue(hint.highlights.isEmpty())
+    fun `fen board parsing places pieces at the right ordinals`() {
+        val board = HintAdvisor.parseFenBoard(startFen)!!
+        assertEquals('R', board[0])   // a1
+        assertEquals('P', board[12])  // e2
+        assertEquals('k', board[60])  // e8
+        assertEquals(null, board[35]) // d5
+        assertNull(HintAdvisor.parseFenBoard("not/a/fen"))
+        assertNull(HintAdvisor.parseFenBoard("8/8/8/8/8/8/8/9 w - - 0 1"))
     }
 
     @Test
-    fun `level one flags winnable material when the best move captures`() {
-        // Best move lands on an enemy queen (h5 = ordinal 39)
-        val hint = HintAdvisor.hint(
-            1,
-            cp(400, "d1h5"),
-            squares(39 to 'q'),
-            topWeakness = null
-        )!!
-        assertTrue(hint.text.contains("win material"))
-    }
-
-    @Test
-    fun `level one personalizes from the top weakness when nothing tactical applies`() {
-        val hint = HintAdvisor.hint(1, cp(50, "g1f3"), squares(), ThemeTag.HANGING_PIECE)!!
-        assertTrue(hint.text.contains("defended"))
-
-        val generic = HintAdvisor.hint(1, cp(50, "g1f3"), squares(), topWeakness = null)!!
-        assertTrue(generic.text.contains("stronger move"))
-    }
-
-    @Test
-    fun `an even trade does not claim to win material`() {
-        // Best move takes a queen but the eval is level — it's a trade
-        // (Qxq, recapture), not a win, so fall through to the generic nudge
-        val hint = HintAdvisor.hint(1, cp(0, "d1d8"), squares(59 to 'q'), null)!!
-        assertTrue(hint.text.contains("stronger move"))
-    }
-
-    @Test
-    fun `pawn captures do not trigger the material cue`() {
-        // Best move captures a pawn (100cp < the 300cp significance floor)
-        val hint = HintAdvisor.hint(1, cp(80, "d4e5"), squares(36 to 'p'), null)!!
-        assertTrue(hint.text.contains("stronger move"))
-    }
-
-    @Test
-    fun `level two names the piece and highlights its square`() {
-        // White knight on g1 (ordinal 6), best move g1f3
-        val hint = HintAdvisor.hint(2, cp(30, "g1f3"), squares(6 to 'N'), null)!!
+    fun `level one names the piece and highlights its square`() {
+        val hint = HintAdvisor.hint(1, cp(30, "g1f3"), startFen)!!
         assertEquals("Look at your knight on g1.", hint.text)
         assertEquals(setOf(6), hint.highlights)
     }
 
     @Test
-    fun `level three reveals the move and both squares`() {
-        val hint = HintAdvisor.hint(3, cp(30, "g1f3"), squares(6 to 'N'), null)!!
-        assertEquals("Best move: g1 → f3.", hint.text)
+    fun `level two reveals the move and both squares`() {
+        val hint = HintAdvisor.hint(2, cp(30, "g1f3"), startFen)!!
+        assertEquals("Play g1 → f3.", hint.text)
         assertEquals(setOf(6, 21), hint.highlights)
     }
 
     @Test
-    fun `no hint without a best move or for out-of-range levels`() {
-        assertNull(HintAdvisor.hint(1, cp(0, null), squares(), null))
-        assertNull(HintAdvisor.hint(0, cp(0, "e2e4"), squares(), null))
-        assertNull(HintAdvisor.hint(4, cp(0, "e2e4"), squares(), null))
-        assertNull(HintAdvisor.hint(1, cp(0, "xx"), squares(), null))
-    }
-
-    @Test
-    fun `promotion lan parses its squares and names the promoted piece`() {
+    fun `promotion names the promoted piece`() {
         // e7e8q: from=e7 (52), to=e8 (60)
-        val hint = HintAdvisor.hint(3, cp(900, "e7e8q"), squares(52 to 'P'), null)!!
+        val fen = "k7/4P3/8/8/8/8/8/K7 w - - 0 1"
+        val hint = HintAdvisor.hint(2, cp(900, "e7e8q"), fen)!!
+        assertEquals("Play e7 → e8 (promote to queen).", hint.text)
         assertEquals(setOf(52, 60), hint.highlights)
-        assertEquals("Best move: e7 → e8 (promote to queen).", hint.text)
     }
 
     @Test
-    fun `getting mated never claims the player has a forced mate`() {
-        // mateIn < 0: the player is the one being mated — the mate cue must
-        // not fire, and with nothing else applicable the nudge stays generic
-        val losing = PositionAnalysis(scoreCp = null, mateIn = -2, bestMoveLan = "g8f8", depth = 12)
-        val hint = HintAdvisor.hint(1, losing, squares(), null)!!
-        assertTrue(hint.text.contains("stronger move"))
-        assertTrue(!hint.text.contains("forced mate"))
+    fun `no hint without a best move or for out-of-range levels`() {
+        assertNull(HintAdvisor.hint(1, cp(0, null), startFen))
+        assertNull(HintAdvisor.hint(0, cp(0, "e2e4"), startFen))
+        assertNull(HintAdvisor.hint(3, cp(0, "e2e4"), startFen))
+        assertNull(HintAdvisor.hint(1, cp(0, "xx"), startFen))
     }
 }

--- a/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
@@ -1,0 +1,97 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.PositionAnalysis
+import com.raichess.domain.model.ThemeTag
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HintAdvisorTest {
+
+    /** Empty board with the given (square ordinal → FEN char) placements. */
+    private fun squares(vararg placements: Pair<Int, Char>): List<Char?> {
+        val board = arrayOfNulls<Char>(64)
+        placements.forEach { (index, piece) -> board[index] = piece }
+        return board.toList()
+    }
+
+    private fun cp(score: Int, best: String?) =
+        PositionAnalysis(scoreCp = score, mateIn = null, bestMoveLan = best, depth = 12)
+
+    @Test
+    fun `square ordinals map lan squares to a1-h8 indexing`() {
+        assertEquals(0, HintAdvisor.squareOrdinal("a1"))
+        assertEquals(12, HintAdvisor.squareOrdinal("e2"))
+        assertEquals(63, HintAdvisor.squareOrdinal("h8"))
+        assertNull(HintAdvisor.squareOrdinal("i1"))
+        assertNull(HintAdvisor.squareOrdinal("a9"))
+        assertNull(HintAdvisor.squareOrdinal("e"))
+    }
+
+    @Test
+    fun `level one prefers the mate cue over everything`() {
+        val analysis = PositionAnalysis(scoreCp = null, mateIn = 2, bestMoveLan = "d1h5", depth = 12)
+        val hint = HintAdvisor.hint(1, analysis, squares(), ThemeTag.HANGING_PIECE)!!
+        assertTrue(hint.text.contains("forced mate"))
+        assertTrue(hint.highlights.isEmpty())
+    }
+
+    @Test
+    fun `level one flags winnable material when the best move captures`() {
+        // Best move lands on an enemy queen (h5 = ordinal 39)
+        val hint = HintAdvisor.hint(
+            1,
+            cp(400, "d1h5"),
+            squares(39 to 'q'),
+            topWeakness = null
+        )!!
+        assertTrue(hint.text.contains("win material"))
+    }
+
+    @Test
+    fun `level one personalizes from the top weakness when nothing tactical applies`() {
+        val hint = HintAdvisor.hint(1, cp(50, "g1f3"), squares(), ThemeTag.HANGING_PIECE)!!
+        assertTrue(hint.text.contains("defended"))
+
+        val generic = HintAdvisor.hint(1, cp(50, "g1f3"), squares(), topWeakness = null)!!
+        assertTrue(generic.text.contains("stronger move"))
+    }
+
+    @Test
+    fun `pawn captures do not trigger the material cue`() {
+        // Best move captures a pawn (100cp < the 300cp significance floor)
+        val hint = HintAdvisor.hint(1, cp(80, "d4e5"), squares(36 to 'p'), null)!!
+        assertTrue(hint.text.contains("stronger move"))
+    }
+
+    @Test
+    fun `level two names the piece and highlights its square`() {
+        // White knight on g1 (ordinal 6), best move g1f3
+        val hint = HintAdvisor.hint(2, cp(30, "g1f3"), squares(6 to 'N'), null)!!
+        assertEquals("Look at your knight on g1.", hint.text)
+        assertEquals(setOf(6), hint.highlights)
+    }
+
+    @Test
+    fun `level three reveals the move and both squares`() {
+        val hint = HintAdvisor.hint(3, cp(30, "g1f3"), squares(6 to 'N'), null)!!
+        assertEquals("Best move: g1 → f3.", hint.text)
+        assertEquals(setOf(6, 21), hint.highlights)
+    }
+
+    @Test
+    fun `no hint without a best move or for out-of-range levels`() {
+        assertNull(HintAdvisor.hint(1, cp(0, null), squares(), null))
+        assertNull(HintAdvisor.hint(0, cp(0, "e2e4"), squares(), null))
+        assertNull(HintAdvisor.hint(4, cp(0, "e2e4"), squares(), null))
+        assertNull(HintAdvisor.hint(1, cp(0, "xx"), squares(), null))
+    }
+
+    @Test
+    fun `promotion lan parses its squares`() {
+        // e7e8q: from=e7 (52), to=e8 (60)
+        val hint = HintAdvisor.hint(3, cp(900, "e7e8q"), squares(52 to 'P'), null)!!
+        assertEquals(setOf(52, 60), hint.highlights)
+    }
+}

--- a/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
@@ -97,9 +97,20 @@ class HintAdvisorTest {
     }
 
     @Test
-    fun `promotion lan parses its squares`() {
+    fun `promotion lan parses its squares and names the promoted piece`() {
         // e7e8q: from=e7 (52), to=e8 (60)
         val hint = HintAdvisor.hint(3, cp(900, "e7e8q"), squares(52 to 'P'), null)!!
         assertEquals(setOf(52, 60), hint.highlights)
+        assertEquals("Best move: e7 → e8 (promote to queen).", hint.text)
+    }
+
+    @Test
+    fun `getting mated never claims the player has a forced mate`() {
+        // mateIn < 0: the player is the one being mated — the mate cue must
+        // not fire, and with nothing else applicable the nudge stays generic
+        val losing = PositionAnalysis(scoreCp = null, mateIn = -2, bestMoveLan = "g8f8", depth = 12)
+        val hint = HintAdvisor.hint(1, losing, squares(), null)!!
+        assertTrue(hint.text.contains("stronger move"))
+        assertTrue(!hint.text.contains("forced mate"))
     }
 }

--- a/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/HintAdvisorTest.kt
@@ -57,10 +57,17 @@ class HintAdvisorTest {
     }
 
     @Test
+    fun `level three phrases the deeper verdict`() {
+        val hint = HintAdvisor.hint(HintAdvisor.DEEP_LEVEL, cp(45, "e2e4"), startFen)!!
+        assertEquals("After a deeper look: play e2 → e4.", hint.text)
+        assertEquals(setOf(12, 28), hint.highlights)
+    }
+
+    @Test
     fun `no hint without a best move or for out-of-range levels`() {
         assertNull(HintAdvisor.hint(1, cp(0, null), startFen))
         assertNull(HintAdvisor.hint(0, cp(0, "e2e4"), startFen))
-        assertNull(HintAdvisor.hint(3, cp(0, "e2e4"), startFen))
+        assertNull(HintAdvisor.hint(HintAdvisor.MAX_LEVEL + 1, cp(0, "e2e4"), startFen))
         assertNull(HintAdvisor.hint(1, cp(0, "xx"), startFen))
     }
 }


### PR DESCRIPTION
Phase C of the coaching roadmap: the player-facing layer over Phase A's analysis. Everything here is **Training mode only** — Rated games get no hints, no ratings, and no extra engine calls, so rating integrity is untouched.

*(Scope note: an earlier revision shipped a three-rung ladder whose first rung was a text nudge, personalized from the Phase B weakness profile. On-device feedback found it read as encouragement rather than help, so it was replaced mid-PR by the board-pointing ladder plus the live rating below. The weakness profile no longer feeds hints; it remains the input for the Phase D practice queue.)*

## Three-tap hint ladder (`HintAdvisor`)

Hints point at the board instead of talking:

1. **The piece** — "Look at your knight on g1", with the square highlighted.
2. **The move** — "Play g1 → f3", both squares highlighted (promotions name the promoted piece).
3. **A deeper look** — a fresh 1.5s search ("After a deeper look: play …"); its result also replaces the cached baseline, so the Win % and the grading of the next move use the better eval. Board input is held during the search, and the hint is only charged if it delivers (a failed search steps back to rung 2 for a retry).

Rungs 1–2 are instant (pure content over the coach's cached analysis; no engine call at tap time). Each rung revealed docks the game's accuracy input exactly like an undo (`UndoPenalty` over undos + hints), so assistance stays priced.

## Live move rating + win chances (`GameViewModel`, `WinProbability`)

In Training, the ViewModel keeps a ~200ms background analysis of each position (the *baseline*) and grades every player move against it. Both results are surfaced in a fixed-height coach line under the status:

> **Good move · Win 62%**

- **Move rating**: Best/Good/Inaccuracy/Mistake/Blunder per `MoveClassifier`'s thresholds; blunders add a "consider Undo" nudge (the tracked Training undo, which records the position into the practice queue, is the recovery path).
- **Win chances**: the baseline eval mapped through a Lichess-style logistic (`WinProbability`, 0cp = 50%, ±300cp ≈ 75/25%).
- The fixed-height slot means appearing/disappearing text never reflows the board.

## Stockfish-quality analysis in every opponent band

- **Dedicated analyzer in the weak band**: RaiEngine-opponent games previously had no Stockfish at all, so coaching there was depth-3 RaiEngine. Training games against a RaiEngine opponent now create a dedicated full-strength Stockfish analyzer (still one WebView per game — weak-band games had none). RaiEngine remains only the WASM-failure fallback.
- **Honest analysis on handicapped instances**: in the Stockfish band the play engine is skill-limited to its ELO; `analyze()` lifts the Skill Level cap for the search and restores it after (fire-and-forget restore, ordered by the Handler's FIFO guarantee).
- **`engineLock`**: all engine calls (searches + coach analyses) serialize through one mutex, preserving `ChessEngine`'s single-caller contract.
- **FEN-tagged analysis cache**: the coach's cached analysis carries the position it was computed for, and every consumer validates it — a slow background analysis can never produce a hint or a grade for the wrong position. Turn handoff never waits on the coach.
- The tricky perspective-flip math lives in the pure, regression-tested `MoveClassifier.lossBetween()`.

## Tests

`HintAdvisorTest` (rung content/highlights incl. the deep rung, FEN board parsing, LAN square mapping incl. promotions, malformed input), `WinProbabilityTest` (symmetry, monotonicity, saturation), and the `lossBetween` sign-flip cases in `MoveClassifierTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p