### PR TITLE
Native Stockfish (jniLibs) replaces the WASM backend

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -10,9 +10,11 @@ on:
       - '**.xml'
       - '**.properties'
       - 'app/src/main/assets/**'
+      - 'app/src/main/cpp/**'
       - 'gradle/**'
       - 'gradlew'
       - 'gradlew.bat'
+      - '.github/workflows/**'
   pull_request:
     branches: [ main, master, develop ]
     paths:
@@ -21,9 +23,11 @@ on:
       - '**.xml'
       - '**.properties'
       - 'app/src/main/assets/**'
+      - 'app/src/main/cpp/**'
       - 'gradle/**'
       - 'gradlew'
       - 'gradlew.bat'
+      - '.github/workflows/**'
 
 jobs:
   build:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -57,6 +57,19 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew assembleDebug --stacktrace
 
+    - name: Verify native Stockfish is packaged
+      run: |
+        APK=app/build/outputs/apk/debug/app-debug.apk
+        echo "APK native libs:"
+        unzip -l "$APK" | grep 'lib/' || true
+        for abi in arm64-v8a armeabi-v7a; do
+          if ! unzip -l "$APK" | grep -q "lib/$abi/libstockfish.so"; then
+            echo "::error::libstockfish.so missing for $abi — the executable-as-jniLib packaging broke"
+            exit 1
+          fi
+        done
+        echo "libstockfish.so present for all ABIs"
+
     - name: Run unit tests
       run: ./gradlew testDebugUnitTest --stacktrace
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,18 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        // Native Stockfish binary (see src/main/cpp/CMakeLists.txt). Real
+        // phones only — emulators/x86 fall back to the WASM backend.
+        ndk {
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a")
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+        }
     }
 
     buildTypes {
@@ -53,6 +65,13 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+        jniLibs {
+            // Extract native libs to nativeLibraryDir instead of loading
+            // them from the APK: libstockfish.so is actually an executable
+            // that StockfishNativeEngine exec()s, which requires a real
+            // file on disk
+            useLegacyPackaging = true
         }
     }
 }

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -42,7 +42,12 @@ add_executable(stockfish ${SF_SOURCES})
 # gets a runnable binary into nativeLibraryDir
 set_target_properties(stockfish PROPERTIES OUTPUT_NAME "libstockfish.so")
 
-target_compile_features(stockfish PRIVATE cxx_std_17)
+# C++11, NOT the NDK's default gnu++17: SF11 predates std::clamp and
+# defines its own, which is ambiguous under C++17
+set_target_properties(stockfish PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+)
 # USE_POPCNT maps to compiler builtins on every NDK target; IS_64BIT only
 # where true (Stockfish's own Makefile does the same per-arch split)
 target_compile_options(stockfish PRIVATE -O3 -DNDEBUG -DUSE_POPCNT -Wno-deprecated-declarations)

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.18)
+project(raichess_stockfish CXX)
+
+# Builds Stockfish as a native executable, disguised as libstockfish.so so
+# AGP packages it into the APK's jniLibs and Android extracts it to
+# nativeLibraryDir (see packaging.jniLibs.useLegacyPackaging in
+# build.gradle.kts), where StockfishNativeEngine exec()s it and speaks UCI
+# over stdin/stdout. This replaces the WebView/WASM backend as the primary
+# engine: field diagnostics showed the 2019 stockfish.js build never
+# finishing initialization on some devices' WebViews.
+#
+# Stockfish 11 specifically: the last classical-evaluation release — no
+# NNUE network file to bundle (SF12+ needs ~40MB nets), still far stronger
+# than any strength the app's ELO slider offers.
+#
+# Sources are downloaded at configure time from the pinned release tag
+# (no hash pin: GitHub guarantees stable source archives for tags, and
+# both CI and local builds fetch over TLS from the official repo).
+set(SF_TAG sf_11)
+set(SF_URL "https://github.com/official-stockfish/Stockfish/archive/refs/tags/${SF_TAG}.zip")
+set(SF_ZIP "${CMAKE_BINARY_DIR}/stockfish-${SF_TAG}.zip")
+set(SF_SRC "${CMAKE_BINARY_DIR}/Stockfish-${SF_TAG}/src")
+
+if(NOT EXISTS "${SF_SRC}/main.cpp")
+    message(STATUS "Downloading Stockfish ${SF_TAG} sources from ${SF_URL}")
+    file(DOWNLOAD "${SF_URL}" "${SF_ZIP}" TLS_VERIFY ON STATUS SF_DL_STATUS)
+    list(GET SF_DL_STATUS 0 SF_DL_CODE)
+    if(NOT SF_DL_CODE EQUAL 0)
+        message(FATAL_ERROR "Stockfish source download failed: ${SF_DL_STATUS}")
+    endif()
+    file(ARCHIVE_EXTRACT INPUT "${SF_ZIP}" DESTINATION "${CMAKE_BINARY_DIR}")
+    if(NOT EXISTS "${SF_SRC}/main.cpp")
+        message(FATAL_ERROR "Stockfish archive did not contain expected sources")
+    endif()
+endif()
+
+file(GLOB SF_SOURCES "${SF_SRC}/*.cpp" "${SF_SRC}/syzygy/*.cpp")
+
+add_executable(stockfish ${SF_SOURCES})
+
+# Executable named like a shared library — the AGP packaging trick that
+# gets a runnable binary into nativeLibraryDir
+set_target_properties(stockfish PROPERTIES OUTPUT_NAME "libstockfish.so")
+
+target_compile_features(stockfish PRIVATE cxx_std_17)
+# USE_POPCNT maps to compiler builtins on every NDK target; IS_64BIT only
+# where true (Stockfish's own Makefile does the same per-arch split)
+target_compile_options(stockfish PRIVATE -O3 -DNDEBUG -DUSE_POPCNT -Wno-deprecated-declarations)
+if(CMAKE_ANDROID_ARCH_ABI MATCHES "64")
+    target_compile_definitions(stockfish PRIVATE IS_64BIT)
+endif()

--- a/app/src/main/java/com/raichess/data/engine/EngineFactory.kt
+++ b/app/src/main/java/com/raichess/data/engine/EngineFactory.kt
@@ -24,16 +24,20 @@ object EngineFactory {
 
     fun create(context: Context, targetElo: Int): ChessEngine {
         val stockfish = usesStockfish(targetElo)
+        val native = stockfish && StockfishNativeEngine.isAvailable(context)
         // Game-start header in the engine log: frames any fallback events
-        // that follow (and makes "1350 → Stockfish" band routing visible)
-        EngineDiagnostics.record(
-            context,
-            "game start: targetElo $targetElo → ${if (stockfish) "Stockfish" else "RaiEngine band"}"
-        )
-        return if (stockfish) {
-            StockfishWasmEngine(context, targetElo, fallback = RaiEngine(targetElo))
-        } else {
-            RaiEngine(targetElo)
+        // that follow, and makes both the band routing and the chosen
+        // backend (native binary vs WASM) visible
+        val backend = when {
+            !stockfish -> "RaiEngine band"
+            native -> "Stockfish (native)"
+            else -> "Stockfish (wasm)"
+        }
+        EngineDiagnostics.record(context, "game start: targetElo $targetElo → $backend")
+        return when {
+            !stockfish -> RaiEngine(targetElo)
+            native -> StockfishNativeEngine(context, targetElo, fallback = RaiEngine(targetElo))
+            else -> StockfishWasmEngine(context, targetElo, fallback = RaiEngine(targetElo))
         }
     }
 
@@ -44,10 +48,19 @@ object EngineFactory {
      * and must [ChessEngine.close] it when the analysis run is done.
      */
     fun createAnalyzer(context: Context): ChessEngine =
-        StockfishWasmEngine(
-            context,
-            targetElo = RaiEngine.MAX_ELO,
-            fallback = RaiEngine(RaiEngine.MAX_ELO),
-            analysisMode = true
-        )
+        if (StockfishNativeEngine.isAvailable(context)) {
+            StockfishNativeEngine(
+                context,
+                targetElo = RaiEngine.MAX_ELO,
+                fallback = RaiEngine(RaiEngine.MAX_ELO),
+                analysisMode = true
+            )
+        } else {
+            StockfishWasmEngine(
+                context,
+                targetElo = RaiEngine.MAX_ELO,
+                fallback = RaiEngine(RaiEngine.MAX_ELO),
+                analysisMode = true
+            )
+        }
 }

--- a/app/src/main/java/com/raichess/data/engine/StockfishNativeEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/StockfishNativeEngine.kt
@@ -1,0 +1,357 @@
+package com.raichess.data.engine
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.move.Move
+import com.raichess.data.diagnostics.EngineDiagnostics
+import com.raichess.domain.model.EloConfiguration
+import com.raichess.domain.model.PositionAnalysis
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * Stockfish opponent backed by a native binary: the CMake step builds
+ * Stockfish from source into `libstockfish.so` (an executable in library
+ * clothing — see src/main/cpp/CMakeLists.txt), Android extracts it to
+ * nativeLibraryDir, and this class exec()s it and speaks UCI over
+ * stdin/stdout. No WebView, no WASM, no JS bridge — this replaces
+ * [StockfishWasmEngine] as the primary backend after field diagnostics
+ * showed the 2019 stockfish.js build never finishing initialization on
+ * some devices' WebViews. The WASM engine remains the backend for ABIs
+ * without the binary (see [EngineFactory]).
+ *
+ * Contracts match the WASM engine exactly: [selectMove]/[analyze] are
+ * synchronous, single-caller, called off the UI thread; any failure falls
+ * back to [fallback] so play never breaks; lifecycle events land in
+ * [EngineDiagnostics].
+ */
+class StockfishNativeEngine(
+    context: Context,
+    targetElo: Int,
+    private val fallback: ChessEngine,
+    /** True for analyzer instances: skill limiting is never applied. */
+    private val analysisMode: Boolean = false
+) : ChessEngine {
+
+    private val appContext = context.applicationContext
+    private val config = EloConfiguration.forElo(targetElo)
+    private val moveTimeMs = config.thinkingTimeMs.coerceIn(300L, 3000L)
+    private val output = LinkedBlockingQueue<String>()
+
+    @Volatile private var process: Process? = null
+    @Volatile private var writer: BufferedWriter? = null
+    @Volatile private var state = State.UNINITIALIZED
+    // Set once, by close() ONLY — permanent teardown. Failed inits stay
+    // retryable (same released/FAILED split as the WASM engine).
+    @Volatile private var released = false
+    @Volatile private var everFellBack = false
+    // True while moves are served by the fallback; cleared on (re)init so
+    // each engagement logs, not just the first.
+    @Volatile private var fallbackActive = false
+    private var initAttempts = 0
+    // Scopes the reader thread to its init attempt, so a stale process's
+    // late output can't pollute a retry's queue. Written only inside the
+    // synchronized ensureReady (directly or via fail()).
+    @Volatile private var attemptGeneration = 0
+
+    private enum class State { UNINITIALIZED, READY, FAILED }
+
+    override val activeEngineLabel: String
+        get() = when {
+            state == State.READY && everFellBack -> "Stockfish (recovered)"
+            state == State.READY -> "Stockfish"
+            everFellBack || state == State.FAILED -> "RaiEngine (fallback)"
+            else -> "Stockfish"
+        }
+
+    /** Start the process early so move one doesn't pay for it. */
+    override fun warmUp() {
+        try {
+            ensureReady()
+        } catch (e: Exception) {
+            // Best-effort by contract — the first real call retries/falls back
+            Log.w(TAG, "warmUp failed", e)
+        }
+    }
+
+    // Single-caller only: shares one output queue across the call, exactly
+    // like the WASM engine. GameViewModel's engineLock guarantees this.
+    override fun selectMove(board: Board): Move? {
+        return try {
+            if (!ensureReady()) {
+                // Torn down (new game closed this instance): quiet null, not
+                // a wasted fallback search on a stale board
+                if (released) return null
+                return fallbackMove(board, "native engine unavailable (init failed)")
+            }
+            if (released) return null
+
+            output.clear()
+            send("ucinewgame")
+            send("position fen ${board.fen}")
+            send("go movetime $moveTimeMs")
+
+            val best = awaitToken(moveTimeMs + BESTMOVE_GRACE_MS) { it.startsWith("bestmove") }
+            if (best == null) {
+                if (released) return null
+                Log.w(TAG, "no bestmove within timeout; using RaiEngine fallback")
+                return fallbackMove(board, "no bestmove within ${moveTimeMs + BESTMOVE_GRACE_MS}ms")
+            }
+            StockfishWasmEngine.parseUciBestMove(board, best)
+                ?: fallbackMove(board, "unparseable bestmove: $best")
+        } catch (e: Exception) {
+            Log.w(TAG, "selectMove failed; using RaiEngine fallback", e)
+            fallbackMove(board, "selectMove threw: ${e.javaClass.simpleName}")
+        }
+    }
+
+    override fun analyze(board: Board, moveTimeMs: Long): PositionAnalysis? {
+        return try {
+            if (!ensureReady()) {
+                if (released) return null
+                return fallbackAnalysis(board, moveTimeMs)
+            }
+            if (released) return null
+
+            // Keep the interface's "never strength-limited" promise on play
+            // instances: lift the skill cap for this search, restore after.
+            // send() is synchronous on this thread, so ordering is trivial.
+            val liftSkillLimit = !analysisMode && config.skillLevel < MAX_SKILL_LEVEL
+            if (liftSkillLimit) send("setoption name Skill Level value $MAX_SKILL_LEVEL")
+            try {
+                analyzeAtCurrentStrength(board, moveTimeMs)
+            } finally {
+                if (liftSkillLimit) config.getUciCommands().forEach { send(it) }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "analyze failed; using fallback analyzer", e)
+            fallbackAnalysis(board, moveTimeMs)
+        }
+    }
+
+    private fun analyzeAtCurrentStrength(board: Board, moveTimeMs: Long): PositionAnalysis? {
+        output.clear()
+        // No ucinewgame between analyses: a warm transposition table is
+        // never wrong, only faster (same rationale as the WASM engine)
+        send("position fen ${board.fen}")
+        send("go movetime $moveTimeMs")
+
+        var lastInfo: UciInfoParser.UciInfo? = null
+        val best = awaitToken(moveTimeMs + BESTMOVE_GRACE_MS) { line ->
+            UciInfoParser.parse(line)?.let { info ->
+                if (info.multipv == 1 && !info.isBound) lastInfo = info
+            }
+            line.startsWith("bestmove")
+        }
+        if (best == null) {
+            if (released) return null
+            return fallbackAnalysis(board, moveTimeMs)
+        }
+        val info = lastInfo ?: return fallbackAnalysis(board, moveTimeMs)
+        val bestMoveLan = StockfishWasmEngine.parseUciBestMove(board, best)
+            ?.toString()?.lowercase()
+        return PositionAnalysis(
+            scoreCp = info.scoreCp,
+            mateIn = info.scoreMate,
+            bestMoveLan = bestMoveLan,
+            pv = info.pv.map { it.lowercase() },
+            depth = info.depth
+        )
+    }
+
+    /**
+     * Deliberately does NOT set [everFellBack]: the label reflects who
+     * serves *moves*, and one slow coaching analysis must not brand the
+     * game "fallback" (same rule as the WASM engine).
+     */
+    private fun fallbackAnalysis(board: Board, moveTimeMs: Long): PositionAnalysis? {
+        return fallback.analyze(board, moveTimeMs)
+    }
+
+    private fun fallbackMove(board: Board, cause: String): Move? {
+        // Transition-logged, not per-move, so a fallback game can't flood
+        // the ring buffer past the init entries that explain it
+        if (!fallbackActive) {
+            EngineDiagnostics.record(appContext, "moves now served by RaiEngine: $cause")
+            fallbackActive = true
+        }
+        everFellBack = true
+        return fallback.selectMove(board)
+    }
+
+    /** Start the process and complete the UCI handshake once. Thread-safe. */
+    @Synchronized
+    private fun ensureReady(): Boolean {
+        if (released) return false
+        when (state) {
+            State.READY -> return true
+            State.FAILED -> {
+                // A transient failure stays retryable, once
+                if (initAttempts >= MAX_INIT_ATTEMPTS) return false
+                state = State.UNINITIALIZED
+            }
+            State.UNINITIALIZED -> Unit
+        }
+        initAttempts++
+        val initStartedAt = SystemClock.elapsedRealtime()
+
+        output.clear()
+        attemptGeneration++
+        val generation = attemptGeneration
+
+        val binary = binaryFile(appContext)
+        if (!binary.exists()) return fail("binary missing at ${binary.name}")
+        try {
+            val proc = ProcessBuilder(binary.absolutePath)
+                .redirectErrorStream(true)
+                .start()
+            process = proc
+            writer = BufferedWriter(OutputStreamWriter(proc.outputStream))
+            startReader(proc, generation)
+        } catch (e: Exception) {
+            Log.w(TAG, "process start failed", e)
+            return fail("process start threw: ${e.javaClass.simpleName}")
+        }
+
+        // Native startup is milliseconds, not a WASM compile — short budgets
+        send("uci")
+        if (awaitToken(HANDSHAKE_TIMEOUT_MS) { it == "uciok" } == null) {
+            return fail("no uciok within ${HANDSHAKE_TIMEOUT_MS}ms")
+        }
+        if (!isReady()) return fail("engine not ready after handshake")
+
+        if (!analysisMode) {
+            config.getUciCommands().forEach { send(it) }
+        }
+        send("setoption name Threads value 1")
+        send("setoption name Hash value 16")
+        if (!isReady()) return fail("engine not ready after options")
+
+        state = State.READY
+        fallbackActive = false
+        val elapsed = SystemClock.elapsedRealtime() - initStartedAt
+        EngineDiagnostics.record(
+            appContext,
+            if (initAttempts > 1 || everFellBack) {
+                "native stockfish recovered (attempt $initAttempts, ${elapsed}ms)"
+            } else {
+                "native stockfish ready (${elapsed}ms)"
+            }
+        )
+        return true
+    }
+
+    /** Pump engine stdout into the shared queue, generation-scoped. */
+    private fun startReader(proc: Process, generation: Int) {
+        val thread = Thread {
+            try {
+                BufferedReader(InputStreamReader(proc.inputStream)).use { reader ->
+                    while (true) {
+                        val line = reader.readLine() ?: break
+                        // A stale attempt's process must not write into the
+                        // queue a newer attempt owns
+                        if (generation != attemptGeneration) break
+                        output.offer(line.trim())
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "reader thread ended", e)
+            }
+            // EOF = process died. Only the owning attempt may signal it.
+            if (generation == attemptGeneration && !released) {
+                output.offer(ERROR_SENTINEL)
+            }
+        }
+        thread.isDaemon = true
+        thread.name = "stockfish-native-reader"
+        thread.start()
+    }
+
+    private fun isReady(): Boolean {
+        send("isready")
+        return awaitToken(HANDSHAKE_TIMEOUT_MS) { it == "readyok" } != null
+    }
+
+    /**
+     * Must only be called from inside [ensureReady]'s lock: the attempt
+     * counters it mutates rely on that single-writer discipline.
+     */
+    private fun fail(reason: String): Boolean {
+        Log.w(TAG, "native Stockfish unavailable ($reason); using RaiEngine fallback")
+        EngineDiagnostics.record(
+            appContext,
+            "native stockfish init failed (attempt $initAttempts/$MAX_INIT_ATTEMPTS): $reason"
+        )
+        state = State.FAILED
+        // Invalidate this attempt's reader immediately; released stays
+        // close()'s permanent signal
+        attemptGeneration++
+        destroyProcess()
+        return false
+    }
+
+    private fun destroyProcess() {
+        val proc = process ?: return
+        process = null
+        writer = null
+        try {
+            proc.destroy()
+        } catch (e: Exception) {
+            Log.w(TAG, "process teardown failed", e)
+        }
+    }
+
+    override fun close() {
+        released = true
+        // Wake any thread blocked in awaitToken
+        output.offer(ERROR_SENTINEL)
+        destroyProcess()
+    }
+
+    private fun send(cmd: String) {
+        val w = writer ?: return
+        w.write(cmd)
+        w.newLine()
+        w.flush()
+    }
+
+    private fun awaitToken(timeoutMs: Long, match: (String) -> Boolean): String? {
+        // Monotonic deadline + short slices re-checking released, exactly
+        // like the WASM engine's wait
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (true) {
+            if (released) return null
+            val remaining = deadline - SystemClock.elapsedRealtime()
+            if (remaining <= 0) return null
+            val slice = remaining.coerceAtMost(POLL_SLICE_MS)
+            val line = output.poll(slice, TimeUnit.MILLISECONDS) ?: continue
+            if (line == ERROR_SENTINEL) return null
+            if (match(line)) return line
+        }
+    }
+
+    companion object {
+        private const val TAG = "StockfishNativeEngine"
+
+        /** The executable the CMake step packages into jniLibs. */
+        fun binaryFile(context: Context): File =
+            File(context.applicationInfo.nativeLibraryDir, "libstockfish.so")
+
+        /** True when this device's APK carries the native binary. */
+        fun isAvailable(context: Context): Boolean = binaryFile(context).exists()
+
+        private const val MAX_SKILL_LEVEL = 20
+        private const val ERROR_SENTINEL = "__error__"
+        private const val HANDSHAKE_TIMEOUT_MS = 5000L
+        private const val BESTMOVE_GRACE_MS = 4000L
+        private const val POLL_SLICE_MS = 200L
+        private const val MAX_INIT_ATTEMPTS = 2
+    }
+}


### PR DESCRIPTION
The engine log from PR #22 proved the WASM backend is dead on the reporting device, not slow: `uciok` acks instantly (from the wrapper's pre-init queue), then 2×30s of silence at the post-options `isready` with no JS error — on both attempts, deterministically. No timeout fixes that.

## The fix: native Stockfish, the standard Android chess-app way
- **`src/main/cpp/CMakeLists.txt`** downloads the pinned `sf_11` release at configure time and compiles it with the NDK as an executable named `libstockfish.so`. SF11 is the last classical-eval release — no ~40MB NNUE net to bundle — and still far beyond the app's strength ceiling.
- AGP packages it into jniLibs; `packaging.jniLibs.useLegacyPackaging = true` extracts it to `nativeLibraryDir` where it can actually be exec()'d.
- **`StockfishNativeEngine`** exec()s the binary and speaks UCI over stdin/stdout — no WebView, no WASM, no JS bridge. It mirrors the WASM engine contract-for-contract: RaiEngine fallback on any failure, retry-once init, generation-scoped reader thread (a stale process's late output can't pollute a retry's queue), the `released`/`FAILED` split, warm-up, and full `EngineDiagnostics` logging (`native stockfish ready (NNms)` / `init failed (attempt N/2): reason`).
- **`EngineFactory`** prefers native when the binary exists; the WASM engine remains the backend for ABIs without it (x86 emulators — `abiFilters` is arm64-v8a + armeabi-v7a). The game-start log line now names the backend: `targetElo 1350 → Stockfish (native)`.
- CI workflow `paths` now include `app/src/main/cpp/**` and the workflow itself.

## Licensing
Unchanged posture: Stockfish stays GPL-3.0 (as the app already is), and building from the pinned source tag at build time keeps source correspondence trivially satisfied.

## Testing
- All Kotlin compiles in local checks; the engine mirrors the field-hardened WASM implementation's concurrency structure.
- **The NDK/CMake build itself is CI-verified only** — this sandbox can't run the NDK, so the first CI run on this PR is the real gate for the native build (NDK auto-provisioning, source download, two-ABI compile, packaging).
- On-device validation after merge: the Engine log should show `game start: targetElo 1350 → Stockfish (native)` followed by `native stockfish ready (NNms)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p)_