### PR TITLE
Gentler inaccuracy grading, lesson plans for Practice, and real-puzzle tooling

### DIFF
--- a/.github/workflows/refresh-puzzles.yml
+++ b/.github/workflows/refresh-puzzles.yml
@@ -1,0 +1,47 @@
+name: Refresh Puzzles
+
+# Manually dispatched: regenerates app/src/main/assets/puzzles/puzzles.csv
+# from the real Lichess puzzle database (CC0) and commits the result to
+# the branch this run is dispatched on. The next Android Build run's
+# PuzzleAssetTest then replays every committed row for legality, so a bad
+# sample can never reach a release unchecked.
+on:
+  workflow_dispatch:
+    inputs:
+      per_bucket:
+        description: Max puzzles per rating-band x theme bucket
+        required: false
+        default: '20'
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install zstandard
+
+      - name: Generate puzzle asset
+        run: python3 tools/fetch_lichess_puzzles.py --per-bucket "${{ github.event.inputs.per_bucket }}"
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add app/src/main/assets/puzzles/puzzles.csv
+          if git diff --cached --quiet; then
+            echo "Asset unchanged — nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: refresh bundled puzzles from the Lichess database (CC0)"
+          git push

--- a/TECHNICAL_PLAN.md
+++ b/TECHNICAL_PLAN.md
@@ -398,8 +398,9 @@ class EloCalculator {
    - Calculate centipawn loss
    - Classify move quality:
      - **Brilliant:** Best move in complex position
-     - **Good:** Within 0.3 pawn advantage of best
-     - **Inaccuracy:** 0.3-1.0 pawn loss
+     - **Good:** Within 0.6 pawn advantage of best (raised from 0.3 on
+       field feedback: near-equal moves read as nagging when flagged)
+     - **Inaccuracy:** 0.6-1.0 pawn loss
      - **Mistake:** 1.0-3.0 pawn loss
      - **Blunder:** 3.0+ pawn loss
 

--- a/app/src/main/java/com/raichess/data/repository/LessonRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/LessonRepository.kt
@@ -1,0 +1,33 @@
+package com.raichess.data.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.raichess.domain.usecase.LessonPlanner
+
+/**
+ * Persists per-lesson solve counts (the only lesson state that is stored
+ * — the plan itself is recomputed from the profile, see LessonPlanner).
+ * Keyed by stable lesson ids so plan reshuffles never lose progress.
+ */
+class LessonRepository(context: Context) {
+
+    private val prefs: SharedPreferences =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun getSolves(): Map<String, Int> =
+        LessonPlanner.decodeSolves(prefs.getString(KEY_SOLVES, null))
+
+    /** Increment a lesson's solve count and return the new count. */
+    fun recordSolve(lessonId: String): Int {
+        val solves = getSolves().toMutableMap()
+        val updated = (solves[lessonId] ?: 0) + 1
+        solves[lessonId] = updated
+        prefs.edit().putString(KEY_SOLVES, LessonPlanner.encodeSolves(solves)).apply()
+        return updated
+    }
+
+    companion object {
+        private const val PREFS_NAME = "raichess_lessons"
+        private const val KEY_SOLVES = "solves"
+    }
+}

--- a/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
+++ b/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
@@ -9,9 +9,9 @@ import kotlin.math.max
 enum class MoveClassification {
     /** The engine's own first choice. */
     BEST,
-    /** Within 0.3 pawns of best. */
+    /** Within 0.6 pawns of best. */
     GOOD,
-    /** 0.3–1.0 pawn loss. */
+    /** 0.6–1.0 pawn loss. */
     INACCURACY,
     /** 1.0–3.0 pawn loss. */
     MISTAKE,
@@ -30,7 +30,11 @@ object MoveClassifier {
     /** Mate scores and runaway evals are clamped to ±this before loss math. */
     const val EVAL_CAP_CP = 1000
 
-    private const val INACCURACY_THRESHOLD_CP = 30
+    // Raised from 30 on field feedback: a move within ~half a pawn of the
+    // engine's choice is close to the same score — often within the noise
+    // of the coach's short searches — and flagging it read as nagging.
+    // "Inaccuracy" now starts where the loss is unambiguous.
+    private const val INACCURACY_THRESHOLD_CP = 60
 
     /** Public: ThemeTagger and the weakness profile gate on mistake-or-worse. */
     const val MISTAKE_THRESHOLD_CP = 100

--- a/app/src/main/java/com/raichess/domain/usecase/DrillSelector.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/DrillSelector.kt
@@ -23,7 +23,7 @@ import kotlin.random.Random
  */
 object DrillSelector {
 
-    enum class Source { MIXED, MISTAKES, PUZZLES }
+    enum class Source { MIXED, MISTAKES, PUZZLES, LESSON }
 
     /** One queued drill: exactly one of [puzzle]/[mistake] is set. */
     data class Drill(
@@ -51,6 +51,13 @@ object DrillSelector {
 
     /** Puzzles this far from the player's ELO are filtered out. */
     private const val RATING_WINDOW = 300
+
+    /**
+     * Lesson difficulty window, skewed upward: lessons exist to stretch,
+     * so at-or-above-level material beats comfortable repetition.
+     */
+    private const val LESSON_WINDOW_BELOW = 150
+    private const val LESSON_WINDOW_ABOVE = 400
 
     /** Spaced repetition: base interval doubles with each successful rep. */
     private const val BASE_INTERVAL_MS = 24L * 60 * 60 * 1000
@@ -120,9 +127,52 @@ object DrillSelector {
         val queue = when (source) {
             Source.MISTAKES -> mistakeQueue
             Source.PUZZLES -> puzzleQueue
-            Source.MIXED -> interleave(mistakeQueue, puzzleQueue)
+            // LESSON has its own entry point (buildLessonQueue); routed
+            // here it degrades to the mixed queue rather than crashing
+            Source.MIXED, Source.LESSON -> interleave(mistakeQueue, puzzleQueue)
         }
         return queue.take(limit)
+    }
+
+    /**
+     * Queue for one lesson (see LessonPlanner): only puzzles carrying the
+     * lesson's themes, in an upward-skewed rating window, interleaved with
+     * the player's own mistakes matching the lesson's weakness tag. Same
+     * ramp/spacing/session-shuffle treatment as the regular queue.
+     */
+    fun buildLessonQueue(
+        lesson: LessonPlanner.Lesson,
+        mistakes: List<MistakeDrill>,
+        puzzles: List<Puzzle>,
+        progressById: Map<String, PracticePosition>,
+        targetRating: Int,
+        nowMs: Long,
+        limit: Int = 20
+    ): List<Drill> {
+        val lessonMistakes = lesson.weaknessTheme?.let { tag ->
+            mistakes.filter { tag in it.themes }
+        } ?: emptyList()
+        val mistakeQueue = orderMistakes(lessonMistakes, progressById, nowMs)
+            .map { Drill(mistake = it) }
+
+        val themed = puzzles.filter { p -> p.themes.any { it in lesson.themes } }
+        val inWindow = themed
+            .filter {
+                it.rating >= targetRating - LESSON_WINDOW_BELOW &&
+                    it.rating <= targetRating + LESSON_WINDOW_ABOVE
+            }
+            .ifEmpty { themed }
+        val selected = inWindow
+            .shuffled(Random(nowMs))
+            .sortedByDescending { isDue(progressById["puzzle:${it.id}"], nowMs) }
+            .take(limit)
+        val (due, notDue) = selected.partition { isDue(progressById["puzzle:${it.id}"], nowMs) }
+        val puzzleQueue = (
+            spaceOutThemes(due.sortedBy { it.rating }) +
+                spaceOutThemes(notDue.sortedBy { it.rating })
+            ).map { Drill(puzzle = it) }
+
+        return interleave(mistakeQueue, puzzleQueue).take(limit)
     }
 
     /** Due-first, then most recent mistakes first (input order preserved). */

--- a/app/src/main/java/com/raichess/domain/usecase/LessonPlanner.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/LessonPlanner.kt
@@ -1,0 +1,132 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.ThemeTag
+
+/**
+ * Builds an ordered lesson plan from the player's profile: first FIX the
+ * top weaknesses the analysis keeps seeing, then EXPAND skill by game
+ * stage — weakest phase first, remaining phases after (opening →
+ * middlegame → endgame). Players with no analyzed games yet get a
+ * default fundamentals curriculum, so the Lesson tab is never empty.
+ *
+ * Pure and recomputed from the profile each time (the same
+ * recompute-don't-migrate principle as WeaknessProfiler); only the
+ * per-lesson solve counts persist (LessonRepository), keyed by stable
+ * lesson ids so a plan reshuffle never loses progress.
+ */
+object LessonPlanner {
+
+    /** Solves needed to complete one lesson. */
+    const val TARGET_SOLVES = 8
+
+    /** Weakness lessons per plan — focus beats coverage. */
+    const val MAX_WEAKNESS_LESSONS = 2
+
+    data class Lesson(
+        /** Stable id ("weakness:hanging_piece", "phase:endgame"). */
+        val id: String,
+        val title: String,
+        val description: String,
+        /** Lichess puzzle themes this lesson draws from. */
+        val themes: Set<String>,
+        /** Tag matching the player's own stored mistakes, when applicable. */
+        val weaknessTheme: ThemeTag? = null,
+        val targetSolves: Int = TARGET_SOLVES
+    )
+
+    private val WEAKNESS_TITLES = mapOf(
+        ThemeTag.HANGING_PIECE to "Stop hanging pieces",
+        ThemeTag.ALLOWED_TACTIC to "Defend against tactics",
+        ThemeTag.ALLOWED_MATE to "See mate threats coming",
+        ThemeTag.MISSED_MATE to "Finish with mate",
+        ThemeTag.MISSED_CAPTURE to "Take what's offered"
+    )
+
+    private val PHASE_LESSONS = mapOf(
+        ThemeTag.OPENING to Lesson(
+            id = "phase:opening",
+            title = "Opening skills",
+            description = "Sharpen how your games begin",
+            themes = DrillSelector.PHASE_TO_LICHESS_THEMES.getValue(ThemeTag.OPENING)
+        ),
+        ThemeTag.MIDDLEGAME to Lesson(
+            id = "phase:middlegame",
+            title = "Middlegame skills",
+            description = "Plans and tactics where most games are decided",
+            themes = DrillSelector.PHASE_TO_LICHESS_THEMES.getValue(ThemeTag.MIDDLEGAME)
+        ),
+        ThemeTag.ENDGAME to Lesson(
+            id = "phase:endgame",
+            title = "Endgame technique",
+            description = "Convert advantages when the board empties",
+            themes = DrillSelector.PHASE_TO_LICHESS_THEMES.getValue(ThemeTag.ENDGAME)
+        )
+    )
+
+    /** The full-phase order used to append phases the profile hasn't seen. */
+    private val ALL_PHASES = listOf(ThemeTag.OPENING, ThemeTag.MIDDLEGAME, ThemeTag.ENDGAME)
+
+    /** Fundamentals curriculum for a profile with no observations yet. */
+    private val DEFAULT_PLAN = listOf(
+        Lesson(
+            id = "core:tactics",
+            title = "Tactics fundamentals",
+            description = "Forks, pins, and skewers — the bread and butter",
+            themes = setOf("fork", "pin", "skewer", "discoveredAttack")
+        ),
+        Lesson(
+            id = "core:mates",
+            title = "Mating patterns",
+            description = "Recognize the standard finishes",
+            themes = setOf("mate", "mateIn1", "mateIn2", "backRankMate")
+        )
+    ) + ALL_PHASES.map { PHASE_LESSONS.getValue(it) }
+
+    /**
+     * The ordered plan: weakness lessons (worst first, capped), then phase
+     * lessons weakest-observed phase first with unobserved phases after.
+     */
+    fun buildPlan(profile: WeaknessProfile): List<Lesson> {
+        // No observations at all → fundamentals first; the appended phase
+        // list below would otherwise make the plan non-empty by construction
+        if (profile.weaknesses.isEmpty() && profile.phases.isEmpty()) return DEFAULT_PLAN
+        val weaknessLessons = profile.weaknesses
+            .take(MAX_WEAKNESS_LESSONS)
+            .mapNotNull { stat ->
+                val themes = DrillSelector.WEAKNESS_TO_LICHESS_THEMES[stat.theme]
+                    ?: return@mapNotNull null
+                Lesson(
+                    id = "weakness:${stat.theme.id}",
+                    title = WEAKNESS_TITLES[stat.theme] ?: "Fix: ${stat.theme.id}",
+                    description = "Seen ${stat.occurrences}× in your recent games",
+                    themes = themes,
+                    weaknessTheme = stat.theme
+                )
+            }
+        val phaseOrder = (profile.phases.map { it.theme } + ALL_PHASES).distinct()
+        val phaseLessons = phaseOrder.mapNotNull { PHASE_LESSONS[it] }
+        return weaknessLessons + phaseLessons
+    }
+
+    /** First lesson not yet solved to target, or null when the plan is done. */
+    fun activeLesson(plan: List<Lesson>, solvesById: Map<String, Int>): Lesson? =
+        plan.firstOrNull { (solvesById[it.id] ?: 0) < it.targetSolves }
+
+    /**
+     * Solve-count codec for SharedPreferences ("id=count;id=count").
+     * Lesson ids contain ':', so '=' and ';' are the delimiters.
+     */
+    fun encodeSolves(solves: Map<String, Int>): String =
+        solves.entries.joinToString(";") { "${it.key}=${it.value}" }
+
+    fun decodeSolves(raw: String?): Map<String, Int> =
+        raw?.takeIf { it.isNotEmpty() }
+            ?.split(';')
+            ?.mapNotNull { entry ->
+                val key = entry.substringBeforeLast('=', "")
+                val count = entry.substringAfterLast('=', "").toIntOrNull()
+                if (key.isEmpty() || count == null) null else key to count
+            }
+            ?.toMap()
+            ?: emptyMap()
+}

--- a/app/src/main/java/com/raichess/ui/practice/PracticeScreen.kt
+++ b/app/src/main/java/com/raichess/ui/practice/PracticeScreen.kt
@@ -48,7 +48,7 @@ fun PracticeScreen(
         )
         Spacer(modifier = Modifier.height(8.dp))
 
-        // Source selector: Mixed / My mistakes / Puzzles
+        // Source selector: Mixed / Mistakes / Puzzles / Lesson
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceEvenly
@@ -56,11 +56,14 @@ fun PracticeScreen(
             SourceChip("Mixed", state.source == DrillSelector.Source.MIXED) {
                 onSourceChanged(DrillSelector.Source.MIXED)
             }
-            SourceChip("My mistakes", state.source == DrillSelector.Source.MISTAKES) {
+            SourceChip("Mistakes", state.source == DrillSelector.Source.MISTAKES) {
                 onSourceChanged(DrillSelector.Source.MISTAKES)
             }
             SourceChip("Puzzles", state.source == DrillSelector.Source.PUZZLES) {
                 onSourceChanged(DrillSelector.Source.PUZZLES)
+            }
+            SourceChip("Lesson", state.source == DrillSelector.Source.LESSON) {
+                onSourceChanged(DrillSelector.Source.LESSON)
             }
         }
         Spacer(modifier = Modifier.height(10.dp))
@@ -78,10 +81,12 @@ fun PracticeScreen(
             state.queueEmpty -> {
                 Spacer(modifier = Modifier.height(24.dp))
                 Text(
-                    text = if (state.source == DrillSelector.Source.MISTAKES) {
-                        "No analyzed mistakes to drill yet — play some Training games first."
-                    } else {
-                        "Nothing to practice right now."
+                    text = when {
+                        state.lessonComplete ->
+                            "Lesson plan complete! New lessons grow as you play more games."
+                        state.source == DrillSelector.Source.MISTAKES ->
+                            "No analyzed mistakes to drill yet — play some Training games first."
+                        else -> "Nothing to practice right now."
                     },
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary,
@@ -89,6 +94,22 @@ fun PracticeScreen(
                 )
             }
             else -> {
+                // Lesson header: the unit being worked plus plan progress
+                state.lessonTitle?.let { title ->
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onBackground
+                    )
+                    state.lessonProgressText?.let { progressText ->
+                        Text(
+                            text = progressText,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                }
                 Text(
                     text = state.sourceLabel,
                     style = MaterialTheme.typography.labelMedium,

--- a/app/src/main/java/com/raichess/ui/practice/PracticeViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/practice/PracticeViewModel.kt
@@ -12,6 +12,7 @@ import com.github.bhlangonijr.chesslib.Square
 import com.github.bhlangonijr.chesslib.move.Move
 import com.github.bhlangonijr.chesslib.move.MoveGenerator
 import com.raichess.data.repository.GameRepository
+import com.raichess.data.repository.LessonRepository
 import com.raichess.data.repository.PlayerProfileRepository
 import com.raichess.data.repository.PracticeRepository
 import com.raichess.data.repository.PuzzleRepository
@@ -20,6 +21,7 @@ import com.raichess.domain.model.PracticeRating
 import com.raichess.domain.model.ThemeTag
 import com.raichess.domain.usecase.DrillSelector
 import com.raichess.domain.usecase.GameAnalyzer
+import com.raichess.domain.usecase.LessonPlanner
 import com.raichess.domain.usecase.PuzzleDrill
 import com.raichess.domain.usecase.WeaknessProfile
 import kotlinx.coroutines.CancellationException
@@ -54,7 +56,13 @@ data class PracticeUiState(
     /** Consecutive solves this session, for streak encouragement. */
     val solvedStreak: Int = 0,
     /** Adaptive puzzle-solving rating (null until first load). */
-    val practiceRating: Int? = null
+    val practiceRating: Int? = null,
+    /** Active lesson title (Lesson source only). */
+    val lessonTitle: String? = null,
+    /** "3 of 8 solved" for the active lesson. */
+    val lessonProgressText: String? = null,
+    /** True when every lesson in the current plan is complete. */
+    val lessonComplete: Boolean = false
 )
 
 /**
@@ -69,10 +77,13 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
     private val practiceRepository = PracticeRepository(application)
     private val gameRepository = GameRepository(application)
     private val profileRepository = PlayerProfileRepository(application)
+    private val lessonRepository = LessonRepository(application)
 
     private var queue: List<DrillSelector.Drill> = emptyList()
     private var queueIndex = 0
     private var loadJob: Job? = null
+    private var activeLessonUnit: LessonPlanner.Lesson? = null
+    private var lessonJustCompleted = false
     private var activePuzzle: PuzzleDrill? = null
     private var activeMistake: DrillSelector.MistakeDrill? = null
     private var board = Board()
@@ -124,6 +135,54 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
             // above: bail before touching queue state
             ensureActive()
             val targetRating = profileRepository.getPracticeRating()
+            lessonJustCompleted = false
+
+            if (source == DrillSelector.Source.LESSON) {
+                val plan = LessonPlanner.buildPlan(profile)
+                val solves = try {
+                    lessonRepository.getSolves()
+                } catch (e: Exception) {
+                    Log.w(TAG, "lesson progress unavailable", e)
+                    emptyMap()
+                }
+                val lesson = LessonPlanner.activeLesson(plan, solves)
+                activeLessonUnit = lesson
+                if (lesson == null) {
+                    _uiState.value = _uiState.value.copy(
+                        loading = false,
+                        queueEmpty = true,
+                        lessonComplete = true,
+                        lessonTitle = null,
+                        lessonProgressText = null,
+                        practiceRating = targetRating
+                    )
+                    return@launch
+                }
+                queue = withContext(Dispatchers.Default) {
+                    DrillSelector.buildLessonQueue(
+                        lesson = lesson,
+                        mistakes = mistakes,
+                        puzzles = puzzles,
+                        progressById = progress,
+                        targetRating = targetRating,
+                        nowMs = System.currentTimeMillis()
+                    )
+                }
+                queueIndex = 0
+                _uiState.value = _uiState.value.copy(
+                    loading = false,
+                    queueEmpty = queue.isEmpty(),
+                    lessonComplete = false,
+                    lessonTitle = lesson.title,
+                    lessonProgressText =
+                        "${(solves[lesson.id] ?: 0)} of ${lesson.targetSolves} solved",
+                    practiceRating = targetRating
+                )
+                if (queue.isNotEmpty()) startDrill(queue[0])
+                return@launch
+            }
+
+            activeLessonUnit = null
             // Off the main thread: the sort is trivial for the seed set but
             // the fetch script can grow the asset to thousands of puzzles
             queue = withContext(Dispatchers.Default) {
@@ -142,6 +201,9 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
             _uiState.value = _uiState.value.copy(
                 loading = false,
                 queueEmpty = queue.isEmpty(),
+                lessonComplete = false,
+                lessonTitle = null,
+                lessonProgressText = null,
                 practiceRating = targetRating
             )
             if (queue.isNotEmpty()) startDrill(queue[0])
@@ -149,6 +211,11 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
     }
 
     fun nextDrill() {
+        // A completed lesson advances the plan: reload picks the next unit
+        if (lessonJustCompleted) {
+            loadQueue(DrillSelector.Source.LESSON)
+            return
+        }
         if (queue.isEmpty()) return
         if (queueIndex + 1 >= queue.size) {
             // Full pass done — rebuild instead of wrapping, so due-ness and
@@ -322,14 +389,38 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
             ?.let { setOf(it.from.ordinal, it.to.ordinal) }
             ?: emptySet()
         val streak = if (solved) state.solvedStreak + 1 else 0
+
+        // Lesson bookkeeping: solves advance the active unit; completing
+        // it flags the next "Next" tap to load the following lesson
+        var lessonProgress: String? = null
+        var lessonDonePrompt: String? = null
+        val lesson = activeLessonUnit
+        if (solved && state.source == DrillSelector.Source.LESSON && lesson != null) {
+            val solves = try {
+                lessonRepository.recordSolve(lesson.id)
+            } catch (e: Exception) {
+                Log.w(TAG, "failed to record lesson solve", e)
+                null
+            }
+            if (solves != null) {
+                lessonProgress =
+                    "${solves.coerceAtMost(lesson.targetSolves)} of ${lesson.targetSolves} solved"
+                if (solves >= lesson.targetSolves) {
+                    lessonJustCompleted = true
+                    lessonDonePrompt = "Lesson complete! Tap Next for your next lesson."
+                }
+            }
+        }
+
         _uiState.value = state.copy(
             squares = boardSnapshot(),
             phase = if (solved) DrillPhase.SOLVED else DrillPhase.FAILED,
-            prompt = if (solved) {
-                if (streak >= 3) "Solved! $streak in a row!" else "Solved!"
-            } else {
-                failPrompt(revealLan)
+            prompt = when {
+                lessonDonePrompt != null -> lessonDonePrompt
+                solved -> if (streak >= 3) "Solved! $streak in a row!" else "Solved!"
+                else -> failPrompt(revealLan)
             },
+            lessonProgressText = lessonProgress ?: state.lessonProgressText,
             selectedSquare = null,
             legalTargets = emptySet(),
             revealHighlights = reveal,

--- a/app/src/test/java/com/raichess/domain/model/MoveClassifierTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/MoveClassifierTest.kt
@@ -16,9 +16,9 @@ class MoveClassifierTest {
     fun `classification thresholds match the technical plan`() {
         // Good: within 0.3 pawns of best
         assertEquals(MoveClassification.GOOD, MoveClassifier.classify(0, playedEngineBest = false))
-        assertEquals(MoveClassification.GOOD, MoveClassifier.classify(29, playedEngineBest = false))
+        assertEquals(MoveClassification.GOOD, MoveClassifier.classify(59, playedEngineBest = false))
         // Inaccuracy: 0.3-1.0 pawn loss
-        assertEquals(MoveClassification.INACCURACY, MoveClassifier.classify(30, playedEngineBest = false))
+        assertEquals(MoveClassification.INACCURACY, MoveClassifier.classify(60, playedEngineBest = false))
         assertEquals(MoveClassification.INACCURACY, MoveClassifier.classify(99, playedEngineBest = false))
         // Mistake: 1.0-3.0 pawn loss
         assertEquals(MoveClassification.MISTAKE, MoveClassifier.classify(100, playedEngineBest = false))

--- a/app/src/test/java/com/raichess/domain/usecase/DrillSelectorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/DrillSelectorTest.kt
@@ -167,6 +167,57 @@ class DrillSelectorTest {
     }
 
     @Test
+    fun `lesson queue keeps only lesson-themed puzzles and matching mistakes`() {
+        val lesson = LessonPlanner.Lesson(
+            id = "weakness:hanging_piece",
+            title = "Stop hanging pieces",
+            description = "",
+            themes = setOf("hangingPiece"),
+            weaknessTheme = ThemeTag.HANGING_PIECE
+        )
+        val otherMistake = DrillSelector.MistakeDrill(
+            id = "mistake:2:4", fen = "f", bestMoveLan = "e2e4", playedLan = "a2a3",
+            themes = setOf(ThemeTag.MISSED_MATE)
+        )
+        val queue = DrillSelector.buildLessonQueue(
+            lesson = lesson,
+            mistakes = listOf(mistake("mistake:1:1"), otherMistake),
+            puzzles = listOf(
+                puzzle("hang", 800, "hangingPiece"),
+                puzzle("mate", 820, "mateIn1")
+            ),
+            progressById = emptyMap(),
+            targetRating = 800,
+            nowMs = now
+        )
+        val puzzleIds = queue.mapNotNull { it.puzzle?.id }
+        val mistakeIds = queue.mapNotNull { it.mistake?.id }
+        assertEquals(listOf("hang"), puzzleIds)
+        assertEquals(listOf("mistake:1:1"), mistakeIds)
+    }
+
+    @Test
+    fun `lesson window skews upward around the target rating`() {
+        val lesson = LessonPlanner.Lesson(
+            id = "core:tactics", title = "t", description = "",
+            themes = setOf("fork")
+        )
+        val queue = DrillSelector.buildLessonQueue(
+            lesson = lesson,
+            mistakes = emptyList(),
+            puzzles = listOf(
+                puzzle("wayBelow", 500, "fork"),
+                puzzle("stretch", 1150, "fork")
+            ),
+            progressById = emptyMap(),
+            targetRating = 800,
+            nowMs = now
+        )
+        // -300 is outside the (-150, +400) lesson window; +350 is inside
+        assertEquals(listOf("stretch"), queue.mapNotNull { it.puzzle?.id })
+    }
+
+    @Test
     fun `equal-priority queues are seed-stable but vary between sessions`() {
         val puzzles = ('a'..'h').map { puzzle("$it", 800, "theme-$it") }
         fun queueAt(seedMs: Long) = DrillSelector.buildQueue(

--- a/app/src/test/java/com/raichess/domain/usecase/LessonPlannerTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/LessonPlannerTest.kt
@@ -1,0 +1,92 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.ThemeTag
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LessonPlannerTest {
+
+    private fun stat(theme: ThemeTag, score: Double) =
+        ThemeStat(theme = theme, score = score, occurrences = 3, avgLossCp = 250.0)
+
+    @Test
+    fun `weakness lessons come first, worst weakness leading`() {
+        val plan = LessonPlanner.buildPlan(
+            WeaknessProfile(
+                weaknesses = listOf(
+                    stat(ThemeTag.HANGING_PIECE, 3.0),
+                    stat(ThemeTag.MISSED_MATE, 1.5)
+                ),
+                phases = listOf(stat(ThemeTag.ENDGAME, 2.0))
+            )
+        )
+        assertEquals("weakness:hanging_piece", plan[0].id)
+        assertEquals("weakness:missed_mate", plan[1].id)
+        assertEquals(ThemeTag.HANGING_PIECE, plan[0].weaknessTheme)
+        assertTrue(plan[0].themes.isNotEmpty())
+    }
+
+    @Test
+    fun `phases follow weaknesses, weakest phase first then the rest`() {
+        val plan = LessonPlanner.buildPlan(
+            WeaknessProfile(
+                weaknesses = listOf(stat(ThemeTag.HANGING_PIECE, 1.0)),
+                phases = listOf(stat(ThemeTag.ENDGAME, 2.0))
+            )
+        )
+        val phaseIds = plan.drop(1).map { it.id }
+        assertEquals(
+            listOf("phase:endgame", "phase:opening", "phase:middlegame"),
+            phaseIds
+        )
+    }
+
+    @Test
+    fun `weakness lessons are capped`() {
+        val plan = LessonPlanner.buildPlan(
+            WeaknessProfile(
+                weaknesses = listOf(
+                    stat(ThemeTag.HANGING_PIECE, 3.0),
+                    stat(ThemeTag.MISSED_MATE, 2.0),
+                    stat(ThemeTag.MISSED_CAPTURE, 1.0)
+                ),
+                phases = emptyList()
+            )
+        )
+        assertEquals(
+            LessonPlanner.MAX_WEAKNESS_LESSONS,
+            plan.count { it.id.startsWith("weakness:") }
+        )
+    }
+
+    @Test
+    fun `empty profile gets the fundamentals curriculum`() {
+        val plan = LessonPlanner.buildPlan(WeaknessProfile.EMPTY)
+        assertTrue(plan.isNotEmpty())
+        assertEquals("core:tactics", plan[0].id)
+        assertTrue(plan.any { it.id == "phase:endgame" })
+    }
+
+    @Test
+    fun `active lesson is the first below target and null when done`() {
+        val plan = LessonPlanner.buildPlan(WeaknessProfile.EMPTY)
+        assertEquals(plan[0].id, LessonPlanner.activeLesson(plan, emptyMap())?.id)
+
+        val firstDone = mapOf(plan[0].id to LessonPlanner.TARGET_SOLVES)
+        assertEquals(plan[1].id, LessonPlanner.activeLesson(plan, firstDone)?.id)
+
+        val allDone = plan.associate { it.id to it.targetSolves }
+        assertNull(LessonPlanner.activeLesson(plan, allDone))
+    }
+
+    @Test
+    fun `solve counts round-trip through the prefs codec`() {
+        val solves = mapOf("weakness:hanging_piece" to 3, "phase:endgame" to 8)
+        assertEquals(solves, LessonPlanner.decodeSolves(LessonPlanner.encodeSolves(solves)))
+        assertTrue(LessonPlanner.decodeSolves(null).isEmpty())
+        assertTrue(LessonPlanner.decodeSolves("").isEmpty())
+        assertTrue(LessonPlanner.decodeSolves("garbage").isEmpty())
+    }
+}

--- a/tools/fetch_lichess_puzzles.py
+++ b/tools/fetch_lichess_puzzles.py
@@ -46,6 +46,8 @@ THEMES = [
     "deflection", "attraction", "sacrifice", "clearance", "doubleCheck",
     "trappedPiece", "xRayAttack", "zugzwang", "quietMove", "defensiveMove",
     "intermezzo", "exposedKing", "kingsideAttack", "capturingDefender",
+    # Phase tags, so the lesson plan's opening/middlegame units have material
+    "opening", "middlegame",
 ]
 BANDS = [(lo, lo + 200) for lo in range(400, 2600, 200)]
 HEADER = ["PuzzleId", "FEN", "Moves", "Rating", "RatingDeviation",


### PR DESCRIPTION
Three related coaching improvements.

## 1. Near-equal moves aren't "inaccuracies"
`MoveClassifier`'s GOOD band widens 0.3 → 0.6 pawns: at the coach's 200ms searches, sub-0.6-pawn deltas are often eval noise, and flagging them read as nagging. Mistake (1.0+) and Blunder (3.0+) unchanged, as are the profile/drills/review (mistake-or-worse gated). Boundary tests updated.

## 2. Lesson plans (new "Lesson" source in Practice)
`LessonPlanner` builds an ordered curriculum from the weakness profile:
- **Fix first**: up to two lessons for the top weaknesses ("Stop hanging pieces — seen 5× in your recent games"), drawing lesson-themed puzzles *and* the player's own matching mistakes.
- **Then expand by stage**: weakest observed phase first, remaining phases after (opening → middlegame → endgame).
- Lesson difficulty skews upward (−150..+400 around the practice rating) — lessons stretch, they don't coast.
- 8 solves complete a unit and advance the plan; progress persists by stable lesson id. Empty profile → fundamentals curriculum, so the tab always has content.

## 3. Real puzzles via CI (fixes "the puzzles are trivial")
The bundled 27-seed asset is the root cause of triviality. New `refresh-puzzles.yml` (manual dispatch) runs `tools/fetch_lichess_puzzles.py` on a CI runner — where lichess.org is reachable — and commits a stratified sample of real Lichess puzzles (CC0) to the branch. `PuzzleAssetTest` replays every committed row on the next build. The script's theme list gains `opening`/`middlegame` so phase lessons have material.

**Action needed**: the automation token can't dispatch workflows, so run it once by hand — Actions → "Refresh Puzzles" → Run workflow → branch `claude/personalized-hints-coaching-tgfrhl`.

## Testing
- `LessonPlannerTest` (plan ordering, weakness cap, fundamentals fallback, advancement, prefs codec) and new `DrillSelectorTest` lesson-queue cases — 20 selector/planner tests pass locally, plus the classifier boundary updates.
- Compose changes (Lesson chip, lesson header) are CI-build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p