### PR TITLE
ELO integrity + quad-tile home & proactive coach

### DIFF
--- a/.github/workflows/calibrate-raiengine.yml
+++ b/.github/workflows/calibrate-raiengine.yml
@@ -46,10 +46,14 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y stockfish
 
     - name: Play calibration matches
+      # The input goes through env, not ${{ }}-interpolation inside run:,
+      # so a crafted value can't inject into the runner shell
+      env:
+        GAMES: ${{ github.event.inputs.games || '12' }}
       run: |
         ./gradlew testDebugUnitTest \
           --tests "com.raichess.calibration.RaiEngineCalibrationTest" \
           -Draichess.calibrate=true \
-          -Draichess.calibrate.games="${{ github.event.inputs.games || '12' }}" \
+          -Draichess.calibrate.games="$GAMES" \
           -Dstockfish.path="$(command -v stockfish)" \
           --stacktrace

--- a/.github/workflows/calibrate-raiengine.yml
+++ b/.github/workflows/calibrate-raiengine.yml
@@ -1,0 +1,55 @@
+name: Calibrate RaiEngine
+
+# Manual cross-validation of RaiEngine's ELO labels: plays every band
+# against a desktop Stockfish limited to known UCI_Elo anchor strengths
+# and reports the implied rating from the match scores. Run it from the
+# Actions tab after touching RaiEngine's strength curve; the report is in
+# the "Play calibration matches" step log.
+on:
+  workflow_dispatch:
+    inputs:
+      games:
+        description: 'Games per band/anchor pairing (more = tighter estimate, slower)'
+        required: false
+        default: '12'
+
+permissions:
+  contents: read
+
+jobs:
+  calibrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        cache-read-only: true
+
+    - name: Install anchor Stockfish
+      run: sudo apt-get update && sudo apt-get install -y stockfish
+
+    - name: Play calibration matches
+      run: |
+        ./gradlew testDebugUnitTest \
+          --tests "com.raichess.calibration.RaiEngineCalibrationTest" \
+          -Draichess.calibrate=true \
+          -Draichess.calibrate.games="${{ github.event.inputs.games || '12' }}" \
+          -Dstockfish.path="$(command -v stockfish)" \
+          --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,22 @@ android {
         buildConfig = true
     }
 
+    testOptions {
+        // Calibration-harness passthrough (see RaiEngineCalibrationTest):
+        // forwards the opt-in flag and Stockfish location from the Gradle
+        // JVM (-D on the command line) into the unit-test JVM, and echoes
+        // test stdout while calibrating so the report lands in the CI log.
+        unitTests.all { test ->
+            listOf("raichess.calibrate", "raichess.calibrate.games", "stockfish.path")
+                .forEach { key ->
+                    System.getProperty(key)?.let { test.systemProperty(key, it) }
+                }
+            if (System.getProperty("raichess.calibrate") == "true") {
+                test.testLogging.showStandardStreams = true
+            }
+        }
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"

--- a/app/src/main/java/com/raichess/MainActivity.kt
+++ b/app/src/main/java/com/raichess/MainActivity.kt
@@ -130,7 +130,9 @@ fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
             onAction = { action ->
                 showCoach = false
                 when (action) {
-                    CoachAdvisor.Action.PLAY_GAME -> showPlaySetup = true
+                    // Same one-tap philosophy as the Play tile: the coach's
+                    // "play a game" starts one, it doesn't open a form
+                    CoachAdvisor.Action.PLAY_GAME -> viewModel.startGame(false)
                     CoachAdvisor.Action.START_LESSON -> {
                         openLessonOnPractice = true
                         showPractice = true
@@ -174,7 +176,12 @@ fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
             HomeScreen(
                 stats = state.playerStats,
                 coachLine = coachState.headline.takeIf { !coachState.loading },
-                onPlay = { showPlaySetup = true },
+                opponentElo = state.opponentElo,
+                gameMode = state.gameMode,
+                // Straight into the game with the current setup; the tile's
+                // corner button is the path to the setup screen
+                onPlay = { viewModel.startGame(false) },
+                onCustomizeGame = { showPlaySetup = true },
                 onTrain = { showPractice = true },
                 onCoach = { showCoach = true },
                 onReview = { showGames = true },

--- a/app/src/main/java/com/raichess/MainActivity.kt
+++ b/app/src/main/java/com/raichess/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -15,17 +16,22 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.raichess.data.analysis.AnalysisCoordinator
-import androidx.compose.runtime.LaunchedEffect
+import com.raichess.domain.usecase.CoachAdvisor
+import com.raichess.domain.usecase.DrillSelector
+import com.raichess.ui.coach.CoachScreen
+import com.raichess.ui.coach.CoachViewModel
 import com.raichess.ui.game.GamePhase
 import com.raichess.ui.game.GameScreen
 import com.raichess.ui.game.GameViewModel
 import com.raichess.ui.games.GamesScreen
 import com.raichess.ui.games.GamesViewModel
 import com.raichess.ui.home.HomeScreen
+import com.raichess.ui.home.PlaySetupScreen
 import com.raichess.ui.practice.PracticeScreen
 import com.raichess.ui.practice.PracticeViewModel
 import com.raichess.ui.review.ReviewScreen
 import com.raichess.ui.review.ReviewViewModel
+import com.raichess.ui.settings.SettingsScreen
 import com.raichess.ui.theme.RaiChessTheme
 
 /**
@@ -58,6 +64,12 @@ fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
     val state by viewModel.uiState.collectAsState()
     var showPractice by rememberSaveable { mutableStateOf(false) }
     var showGames by rememberSaveable { mutableStateOf(false) }
+    var showCoach by rememberSaveable { mutableStateOf(false) }
+    var showSettings by rememberSaveable { mutableStateOf(false) }
+    var showPlaySetup by rememberSaveable { mutableStateOf(false) }
+    // Set when the coach's action opens practice: switch to the lesson
+    // queue on entry instead of the default mixed queue
+    var openLessonOnPractice by rememberSaveable { mutableStateOf(false) }
     // -1 = no game open; rememberSaveable needs a non-null primitive
     var reviewGameId by rememberSaveable { mutableStateOf(-1L) }
 
@@ -91,6 +103,12 @@ fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
     if (showPractice) {
         val practiceViewModel: PracticeViewModel = viewModel()
         val practiceState by practiceViewModel.uiState.collectAsState()
+        LaunchedEffect(openLessonOnPractice) {
+            if (openLessonOnPractice) {
+                practiceViewModel.setSource(DrillSelector.Source.LESSON)
+                openLessonOnPractice = false
+            }
+        }
         PracticeScreen(
             state = practiceState,
             onSquareTapped = practiceViewModel::onSquareTapped,
@@ -101,21 +119,68 @@ fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
         return
     }
 
-    when (state.phase) {
-        GamePhase.SETUP -> HomeScreen(
-            stats = state.playerStats,
-            opponentElo = state.opponentElo,
-            playerColor = state.playerColor,
-            gameMode = state.gameMode,
-            animationsEnabled = state.animationsEnabled,
-            onOpponentEloChanged = viewModel::setOpponentElo,
-            onPlayerColorChanged = viewModel::setPlayerColor,
-            onGameModeChanged = viewModel::setGameMode,
-            onAnimationsChanged = viewModel::setAnimationsEnabled,
-            onStartGame = viewModel::startGame,
-            onPractice = { showPractice = true },
-            onReview = { showGames = true }
+    if (showCoach) {
+        val coachViewModel: CoachViewModel = viewModel()
+        val coachState by coachViewModel.uiState.collectAsState()
+        // Recompute on every entry: games and drills since the last visit
+        // change the advice
+        LaunchedEffect(Unit) { coachViewModel.refresh() }
+        CoachScreen(
+            state = coachState,
+            onAction = { action ->
+                showCoach = false
+                when (action) {
+                    CoachAdvisor.Action.PLAY_GAME -> showPlaySetup = true
+                    CoachAdvisor.Action.START_LESSON -> {
+                        openLessonOnPractice = true
+                        showPractice = true
+                    }
+                    CoachAdvisor.Action.REVIEW_GAMES -> showGames = true
+                }
+            },
+            onBack = { showCoach = false }
         )
+        return
+    }
+
+    if (showSettings) {
+        SettingsScreen(
+            stats = state.playerStats,
+            animationsEnabled = state.animationsEnabled,
+            onAnimationsChanged = viewModel::setAnimationsEnabled,
+            onBack = { showSettings = false }
+        )
+        return
+    }
+
+    when (state.phase) {
+        GamePhase.SETUP -> if (showPlaySetup) {
+            PlaySetupScreen(
+                stats = state.playerStats,
+                opponentElo = state.opponentElo,
+                playerColor = state.playerColor,
+                gameMode = state.gameMode,
+                onOpponentEloChanged = viewModel::setOpponentElo,
+                onPlayerColorChanged = viewModel::setPlayerColor,
+                onGameModeChanged = viewModel::setGameMode,
+                onStartGame = viewModel::startGame,
+                onBack = { showPlaySetup = false }
+            )
+        } else {
+            val coachViewModel: CoachViewModel = viewModel()
+            val coachState by coachViewModel.uiState.collectAsState()
+            // Keep the Coach tile's one-liner current with the latest games
+            LaunchedEffect(Unit) { coachViewModel.refresh() }
+            HomeScreen(
+                stats = state.playerStats,
+                coachLine = coachState.headline.takeIf { !coachState.loading },
+                onPlay = { showPlaySetup = true },
+                onTrain = { showPractice = true },
+                onCoach = { showCoach = true },
+                onReview = { showGames = true },
+                onSettings = { showSettings = true }
+            )
+        }
 
         GamePhase.PLAYING, GamePhase.GAME_OVER -> GameScreen(
             state = state,

--- a/app/src/main/java/com/raichess/MainActivity.kt
+++ b/app/src/main/java/com/raichess/MainActivity.kt
@@ -165,7 +165,12 @@ fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
                 onOpponentEloChanged = viewModel::setOpponentElo,
                 onPlayerColorChanged = viewModel::setPlayerColor,
                 onGameModeChanged = viewModel::setGameMode,
-                onStartGame = viewModel::startGame,
+                // Close the setup screen as the game starts: post-game
+                // "New Game" then lands on home, never back on this form
+                onStartGame = { random ->
+                    showPlaySetup = false
+                    viewModel.startGame(random)
+                },
                 onBack = { showPlaySetup = false }
             )
         } else {

--- a/app/src/main/java/com/raichess/data/repository/PlayerProfileRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/PlayerProfileRepository.kt
@@ -58,11 +58,14 @@ class PlayerProfileRepository(context: Context) {
      *
      * @param moveAccuracy player's accuracy for the game (50.0 = neutral until
      *   post-game analysis is implemented)
+     * @param assistedMoves hints + undos used this game; scales rating gains
+     *   down (see [EloCalculator.assistedGainFactor])
      */
     fun recordResult(
         result: GameResult,
         opponentElo: Int,
-        moveAccuracy: Double = 50.0
+        moveAccuracy: Double = 50.0,
+        assistedMoves: Int = 0
     ): Pair<EloStats, Int> {
         val stats = getStats()
         val newElo = EloCalculator.calculateNewElo(
@@ -70,7 +73,8 @@ class PlayerProfileRepository(context: Context) {
             opponentElo = opponentElo,
             result = result,
             moveAccuracy = moveAccuracy,
-            gamesPlayed = stats.gamesPlayed
+            gamesPlayed = stats.gamesPlayed,
+            assistedMoves = assistedMoves
         )
         val delta = newElo - stats.currentElo
         val updated = stats.withGameResult(newElo, result)

--- a/app/src/main/java/com/raichess/domain/model/EloCalculator.kt
+++ b/app/src/main/java/com/raichess/domain/model/EloCalculator.kt
@@ -1,5 +1,7 @@
 package com.raichess.domain.model
 
+import kotlin.math.max
+
 /**
  * ELO rating calculator for RaiChess.
  * Uses a modified ELO system that accounts for move accuracy in addition to game results.
@@ -28,6 +30,18 @@ object EloCalculator {
         else -> K_FACTOR
     }
 
+    /** Fraction of a rating GAIN lost per assisted move (hint rung/undo). */
+    const val ASSIST_GAIN_PENALTY = 0.20
+
+    /**
+     * Multiplier on positive rating changes for a game with [assistedMoves]
+     * hints/undos: 1 assist keeps 80% of the gain, 5+ keep nothing. Applies
+     * to gains only — a loss still costs full price, so assistance can
+     * never shield a rating, only stop it from being inflated.
+     */
+    fun assistedGainFactor(assistedMoves: Int): Double =
+        max(0.0, 1.0 - ASSIST_GAIN_PENALTY * assistedMoves)
+
     /**
      * Calculate new ELO rating after a game
      *
@@ -37,6 +51,8 @@ object EloCalculator {
      * @param moveAccuracy Player's move accuracy percentage (0.0 - 100.0)
      * @param gamesPlayed Completed games before this one; drives the
      *   provisional K (defaults to an established rating's K)
+     * @param assistedMoves Hints + undos used this game; scales positive
+     *   rating changes down (see [assistedGainFactor])
      * @return New ELO rating
      */
     fun calculateNewElo(
@@ -44,7 +60,8 @@ object EloCalculator {
         opponentElo: Int,
         result: GameResult,
         moveAccuracy: Double,
-        gamesPlayed: Int = DEVELOPING_GAMES
+        gamesPlayed: Int = DEVELOPING_GAMES,
+        assistedMoves: Int = 0
     ): Int {
         // Expected score using standard ELO formula
         val expectedScore = calculateExpectedScore(currentElo, opponentElo)
@@ -64,8 +81,15 @@ object EloCalculator {
         val adjustedActualScore = (actualScore + accuracyBonus * 0.3).coerceIn(0.0, 1.0)
 
         // Calculate rating change
-        val ratingChange =
+        val rawChange =
             (kFactorFor(gamesPlayed) * (adjustedActualScore - expectedScore)).toInt()
+        // A heavily-assisted win is the engine's win, not the player's:
+        // gains shrink with assistance, losses never do
+        val ratingChange = if (rawChange > 0) {
+            (rawChange * assistedGainFactor(assistedMoves)).toInt()
+        } else {
+            rawChange
+        }
 
         // Apply change and clamp to valid range
         return (currentElo + ratingChange).coerceIn(MIN_ELO, MAX_ELO)

--- a/app/src/main/java/com/raichess/domain/usecase/CoachAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/CoachAdvisor.kt
@@ -19,7 +19,11 @@ import kotlin.math.roundToInt
  */
 object CoachAdvisor {
 
-    /** What the coach suggests doing next. */
+    /**
+     * What the coach suggests doing next. REVIEW_GAMES is wired in the UI
+     * but not yet produced by [advise] — reserved for a future
+     * "review that loss" recommendation.
+     */
     enum class Action { PLAY_GAME, START_LESSON, REVIEW_GAMES }
 
     data class Advice(
@@ -78,7 +82,7 @@ object CoachAdvisor {
             // mention, so "work on your openings" advice isn't crowded out
             if (weakness != null && phase != null) {
                 add(
-                    "Most of it happens in ${PHASE_TALK.getValue(phase.theme)} — " +
+                    "Most of it happens in ${phaseName(phase.theme)} — " +
                         "we'll aim your practice there."
                 )
             }
@@ -121,9 +125,15 @@ object CoachAdvisor {
     }
 
     private fun phaseTalk(stat: ThemeStat): Pair<String, String> =
-        "Let's work on ${PHASE_TALK.getValue(stat.theme)}." to
+        "Let's work on ${phaseName(stat.theme)}." to
             "That's where your mistakes cluster right now — I'll steer your " +
             "drills toward that part of the game."
+
+    // Fallback mirrors WEAKNESS_TALK's: a phase tag added to the taxonomy
+    // without a PHASE_TALK entry must degrade the wording, not crash the
+    // coach screen
+    private fun phaseName(theme: ThemeTag): String =
+        PHASE_TALK[theme] ?: "that part of the game"
 
     // headline to observation; the observation reads naturally before
     // ": I've counted it N× in your recent games"

--- a/app/src/main/java/com/raichess/domain/usecase/CoachAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/CoachAdvisor.kt
@@ -1,0 +1,153 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.EloCalculator
+import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.ThemeTag
+import kotlin.math.roundToInt
+
+/**
+ * The coach's voice: turns the player's data (rating, weakness profile,
+ * lesson plan) into personal talking points — "let's work on your
+ * endgames", "you've been leaving pieces en prise" — plus one suggested
+ * next action. Pure and deterministic: same profile, same words, so the
+ * coach doesn't contradict itself between screens.
+ *
+ * Tone rules: always "we"/"let's" (coach and player are on the same
+ * side), always grounded in an observation the player can verify ("I've
+ * counted it 4× in your recent games"), never scolding — a weakness is
+ * the next thing to train, not a failing.
+ */
+object CoachAdvisor {
+
+    /** What the coach suggests doing next. */
+    enum class Action { PLAY_GAME, START_LESSON, REVIEW_GAMES }
+
+    data class Advice(
+        /** Short personal lead ("Let's keep your pieces safe."). */
+        val headline: String,
+        /** The observation behind it, one or two sentences. */
+        val detail: String,
+        /** Extra talking points: calibration, streaks, lesson progress. */
+        val focuses: List<String>,
+        val action: Action,
+        val actionLabel: String
+    )
+
+    fun advise(
+        stats: EloStats?,
+        profile: WeaknessProfile,
+        plan: List<LessonPlanner.Lesson>,
+        solves: Map<String, Int>
+    ): Advice {
+        val gamesPlayed = stats?.gamesPlayed ?: 0
+        if (gamesPlayed == 0) return welcome(plan)
+
+        val lesson = LessonPlanner.activeLesson(plan, solves)
+        val weakness = profile.weaknesses.firstOrNull()
+        val phase = profile.phases.firstOrNull()
+
+        val (headline, detail) = when {
+            weakness != null -> weaknessTalk(weakness)
+            phase != null -> phaseTalk(phase)
+            else -> "Looking sharp." to
+                "No recurring weakness stands out in your recent games. " +
+                "Keep playing — every game teaches me more about your style."
+        }
+
+        val focuses = buildList {
+            if (stats != null && gamesPlayed < EloCalculator.PROVISIONAL_GAMES) {
+                add(
+                    "We're still placing your rating (game ${gamesPlayed + 1} of " +
+                        "${EloCalculator.PROVISIONAL_GAMES}) — expect big swings " +
+                        "while I find your level."
+                )
+            }
+            if (stats != null && stats.winStreak >= 2) {
+                add(
+                    "${stats.winStreak} wins in a row — whatever you're doing, " +
+                        "keep doing it."
+                )
+            }
+            if (lesson != null) {
+                val done = (solves[lesson.id] ?: 0).coerceAtMost(lesson.targetSolves)
+                add("Current lesson: ${lesson.title} — $done of ${lesson.targetSolves} solved.")
+            } else if (plan.isNotEmpty()) {
+                add("Your training plan is complete — new games will seed the next one.")
+            }
+            // When a substantive weakness leads, the phase still gets a
+            // mention, so "work on your openings" advice isn't crowded out
+            if (weakness != null && phase != null) {
+                add(
+                    "Most of it happens in ${PHASE_TALK.getValue(phase.theme)} — " +
+                        "we'll aim your practice there."
+                )
+            }
+        }
+
+        return if (lesson != null) {
+            Advice(headline, detail, focuses, Action.START_LESSON, "Continue: ${lesson.title}")
+        } else {
+            Advice(headline, detail, focuses, Action.PLAY_GAME, "Play a game")
+        }
+    }
+
+    /** First-run voice: no games yet, nothing to diagnose. */
+    private fun welcome(plan: List<LessonPlanner.Lesson>): Advice {
+        val opener = plan.firstOrNull()?.title ?: "the fundamentals"
+        return Advice(
+            headline = "Welcome — I'm Rai, your coach.",
+            detail = "Play a game or two so I can see how you play. I watch " +
+                "every move — win or lose — and build your training plan " +
+                "from what actually happens on your board.",
+            focuses = listOf("Until then, we'll warm up with $opener."),
+            action = Action.PLAY_GAME,
+            actionLabel = "Play your first game"
+        )
+    }
+
+    private fun weaknessTalk(stat: ThemeStat): Pair<String, String> {
+        val talk = WEAKNESS_TALK[stat.theme]
+            ?: ("Let's train a pattern I keep seeing." to "One mistake type keeps recurring")
+        val pawns = (stat.avgLossCp / 100).roundToInt()
+        val cost = if (pawns >= 1) {
+            " — costing about $pawns ${if (pawns == 1) "pawn" else "pawns"} of position each time"
+        } else {
+            ""
+        }
+        val times = if (stat.occurrences == 1) "once" else "${stat.occurrences}×"
+        return talk.first to
+            "${talk.second}: I've counted it $times in your recent games$cost. " +
+            "Let's train it out."
+    }
+
+    private fun phaseTalk(stat: ThemeStat): Pair<String, String> =
+        "Let's work on ${PHASE_TALK.getValue(stat.theme)}." to
+            "That's where your mistakes cluster right now — I'll steer your " +
+            "drills toward that part of the game."
+
+    // headline to observation; the observation reads naturally before
+    // ": I've counted it N× in your recent games"
+    private val WEAKNESS_TALK = mapOf(
+        ThemeTag.HANGING_PIECE to
+            ("Let's keep your pieces safe." to
+                "Pieces keep getting left where they can be taken"),
+        ThemeTag.ALLOWED_TACTIC to
+            ("Let's tighten your defense." to
+                "Opponent tactics keep breaking through"),
+        ThemeTag.ALLOWED_MATE to
+            ("Let's spot mate threats sooner." to
+                "Checkmate threats have been slipping past you"),
+        ThemeTag.MISSED_MATE to
+            ("Let's finish with mate." to
+                "You've had forced mates on the board and let them go"),
+        ThemeTag.MISSED_CAPTURE to
+            ("Let's take what's offered." to
+                "Winning captures keep going unclaimed")
+    )
+
+    private val PHASE_TALK = mapOf(
+        ThemeTag.OPENING to "your openings",
+        ThemeTag.MIDDLEGAME to "your middlegame",
+        ThemeTag.ENDGAME to "your endgames"
+    )
+}

--- a/app/src/main/java/com/raichess/ui/coach/CoachScreen.kt
+++ b/app/src/main/java/com/raichess/ui/coach/CoachScreen.kt
@@ -1,0 +1,188 @@
+package com.raichess.ui.coach
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.raichess.domain.usecase.CoachAdvisor
+import com.raichess.ui.components.RaiLogo
+import com.raichess.ui.components.SectionLabel
+import com.raichess.ui.theme.ChessColors
+
+/**
+ * The coach's corner: personal talking points from CoachAdvisor (what
+ * we're working on and why), one suggested next action, and the lesson
+ * plan with progress.
+ */
+@Composable
+fun CoachScreen(
+    state: CoachUiState,
+    onAction: (CoachAdvisor.Action) -> Unit,
+    onBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 28.dp, vertical = 40.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RaiLogo(size = 36.dp)
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = "Coach",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+        }
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        if (state.loading) {
+            Text(
+                "Thinking…",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary
+            )
+        } else {
+            // The coach's message
+            Text(
+                text = state.headline,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = state.detail,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp)
+            )
+
+            if (state.focuses.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(18.dp))
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    state.focuses.forEach { focus ->
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = "·",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.secondary
+                            )
+                            Text(
+                                text = focus,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onBackground,
+                                modifier = Modifier.padding(start = 8.dp)
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(
+                onClick = { onAction(state.action) },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(state.actionLabel)
+            }
+
+            if (state.planRows.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(28.dp))
+                SectionLabel(
+                    text = "Your plan",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 10.dp)
+                )
+                val shape = RoundedCornerShape(12.dp)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(shape)
+                        .border(1.dp, ChessColors.SquareBorder.copy(alpha = 0.35f), shape)
+                        .padding(horizontal = 14.dp, vertical = 6.dp)
+                ) {
+                    state.planRows.forEach { row ->
+                        PlanRow(row)
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(28.dp))
+        OutlinedButton(
+            onClick = onBack,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Back")
+        }
+    }
+}
+
+@Composable
+private fun PlanRow(row: CoachPlanRow) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = row.title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = if (row.active) FontWeight.Medium else FontWeight.Normal,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Text(
+                text = row.description,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+        Text(
+            text = when {
+                row.done -> "✓"
+                row.active -> "▸ ${row.progressText}"
+                else -> row.progressText
+            },
+            fontSize = 13.sp,
+            color = if (row.done) {
+                ChessColors.ControlActive
+            } else {
+                MaterialTheme.colorScheme.secondary
+            },
+            modifier = Modifier.padding(start = 10.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/raichess/ui/coach/CoachViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/coach/CoachViewModel.kt
@@ -1,0 +1,101 @@
+package com.raichess.ui.coach
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.raichess.data.repository.GameRepository
+import com.raichess.data.repository.LessonRepository
+import com.raichess.data.repository.PlayerProfileRepository
+import com.raichess.domain.usecase.CoachAdvisor
+import com.raichess.domain.usecase.LessonPlanner
+import com.raichess.domain.usecase.WeaknessProfile
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/** One lesson-plan row on the coach screen. */
+data class CoachPlanRow(
+    val id: String,
+    val title: String,
+    val description: String,
+    /** "3 of 8" */
+    val progressText: String,
+    val done: Boolean,
+    /** The unit the next lesson session opens. */
+    val active: Boolean
+)
+
+data class CoachUiState(
+    val loading: Boolean = true,
+    val headline: String = "",
+    val detail: String = "",
+    val focuses: List<String> = emptyList(),
+    val action: CoachAdvisor.Action = CoachAdvisor.Action.PLAY_GAME,
+    val actionLabel: String = "",
+    val planRows: List<CoachPlanRow> = emptyList()
+)
+
+/**
+ * Assembles the coach's view: advice (CoachAdvisor over stats + weakness
+ * profile) and the lesson plan with progress. Recomputed on every
+ * [refresh] — the underlying data changes after each game and drill.
+ */
+class CoachViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val gameRepository = GameRepository(application)
+    private val profileRepository = PlayerProfileRepository(application)
+    private val lessonRepository = LessonRepository(application)
+
+    private val _uiState = MutableStateFlow(CoachUiState())
+    val uiState: StateFlow<CoachUiState> = _uiState
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            val profile = try {
+                gameRepository.weaknessProfile()
+            } catch (e: Exception) {
+                Log.w(TAG, "weakness profile unavailable", e)
+                WeaknessProfile.EMPTY
+            }
+            val stats = profileRepository.getStats()
+            val plan = LessonPlanner.buildPlan(profile)
+            val solves = try {
+                lessonRepository.getSolves()
+            } catch (e: Exception) {
+                Log.w(TAG, "lesson progress unavailable", e)
+                emptyMap()
+            }
+            val advice = CoachAdvisor.advise(stats, profile, plan, solves)
+            val active = LessonPlanner.activeLesson(plan, solves)
+
+            _uiState.value = CoachUiState(
+                loading = false,
+                headline = advice.headline,
+                detail = advice.detail,
+                focuses = advice.focuses,
+                action = advice.action,
+                actionLabel = advice.actionLabel,
+                planRows = plan.map { lesson ->
+                    val done = (solves[lesson.id] ?: 0).coerceAtMost(lesson.targetSolves)
+                    CoachPlanRow(
+                        id = lesson.id,
+                        title = lesson.title,
+                        description = lesson.description,
+                        progressText = "$done of ${lesson.targetSolves}",
+                        done = done >= lesson.targetSolves,
+                        active = lesson.id == active?.id
+                    )
+                }
+            )
+        }
+    }
+
+    companion object {
+        private const val TAG = "CoachViewModel"
+    }
+}

--- a/app/src/main/java/com/raichess/ui/components/Controls.kt
+++ b/app/src/main/java/com/raichess/ui/components/Controls.kt
@@ -1,0 +1,164 @@
+package com.raichess.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.raichess.ui.theme.ChessColors
+
+/**
+ * Shared form controls for the setup-style screens (home, play setup,
+ * settings): eyebrow-labelled sections, the segmented control, and the
+ * framed record row. Extracted from HomeScreen when it became a launcher.
+ */
+
+/** A labelled section: an uppercase eyebrow above its content. */
+@Composable
+internal fun Section(label: String, content: @Composable () -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        SectionLabel(text = label, modifier = Modifier.padding(bottom = 11.dp))
+        content()
+    }
+}
+
+/** Uppercase, wide-tracked eyebrow label. */
+@Composable
+internal fun SectionLabel(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.secondary,
+        letterSpacing = 2.sp,
+        modifier = modifier
+    )
+}
+
+@Composable
+internal fun TickLabel(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.secondary
+    )
+}
+
+/** Two-or-more option segmented control; the selected cell is filled. */
+@Composable
+internal fun SegmentedControl(
+    options: List<String>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val shape = RoundedCornerShape(12.dp)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min)
+            .clip(shape)
+            .border(1.dp, ChessColors.SquareBorder.copy(alpha = 0.35f), shape)
+    ) {
+        options.forEachIndexed { index, label ->
+            if (index > 0) {
+                Box(
+                    modifier = Modifier
+                        .width(1.dp)
+                        .fillMaxHeight()
+                        .background(ChessColors.SquareBorder.copy(alpha = 0.35f))
+                )
+            }
+            val selected = index == selectedIndex
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .background(if (selected) ChessColors.ControlActive else Color.Transparent)
+                    .clickable { onSelect(index) }
+                    .padding(vertical = 12.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal,
+                    color = if (selected) Color.Black else MaterialTheme.colorScheme.secondary
+                )
+            }
+        }
+    }
+}
+
+/** Framed Won / Drew / Lost record. */
+@Composable
+internal fun RecordRow(
+    wins: Int,
+    draws: Int,
+    losses: Int,
+    modifier: Modifier = Modifier
+) {
+    val line = ChessColors.SquareBorder.copy(alpha = 0.35f)
+    val shape = RoundedCornerShape(12.dp)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min)
+            .clip(shape)
+            .border(1.dp, line, shape)
+    ) {
+        RecordCell(label = "Won", value = wins, modifier = Modifier.weight(1f))
+        Box(
+            modifier = Modifier
+                .width(1.dp)
+                .fillMaxHeight()
+                .background(line)
+        )
+        RecordCell(label = "Drew", value = draws, modifier = Modifier.weight(1f))
+        Box(
+            modifier = Modifier
+                .width(1.dp)
+                .fillMaxHeight()
+                .background(line)
+        )
+        RecordCell(label = "Lost", value = losses, modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun RecordCell(label: String, value: Int, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(vertical = 11.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "$value",
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            letterSpacing = 1.5.sp,
+            color = MaterialTheme.colorScheme.secondary,
+            modifier = Modifier.padding(top = 3.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -774,11 +774,19 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         } else {
             UndoPenalty.NEUTRAL_ACCURACY
         }
+        // Beyond the accuracy dock, assisted moves gate the rating gain
+        // itself: a win carried by hints/undos shouldn't inflate ELO
+        // (Rated mode disables both, so this is always 0 there)
+        val assistedMoves = if (state.gameMode == GameMode.TRAINING) {
+            gameUndoCount + gameHintCount
+        } else {
+            0
+        }
         // Peak comparison must use the pre-game stats: recordResult already
         // folded this game into peakElo, so equality afterwards can't tell
         // a fresh high from re-climbing to a previous one
         val previousPeak = state.playerStats?.peakElo
-        val (stats, delta) = repository.recordResult(result, state.opponentElo, accuracy)
+        val (stats, delta) = repository.recordResult(result, state.opponentElo, accuracy, assistedMoves)
         persistFinishedGame(state, result, eloAfter = stats.currentElo, eloDelta = delta)
         // Calibration: while the rating is provisional (and moving fast,
         // see EloCalculator's K bands), the next opponent auto-tracks it —

--- a/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
@@ -147,7 +147,7 @@ fun HomeScreen(
             )
             Text(
                 text = if (gameMode == GameMode.TRAINING) {
-                    "Undo allowed — undos are tracked and reduce ELO gains"
+                    "Undo and hints allowed — each use shrinks ELO gains"
                 } else {
                     "No takebacks — full ELO stakes"
                 },

--- a/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
@@ -1,78 +1,51 @@
 package com.raichess.ui.home
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Slider
-import androidx.compose.material3.SliderDefaults
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.raichess.BuildConfig
-import com.raichess.data.diagnostics.EngineDiagnostics
-import com.raichess.data.engine.RaiEngine
-import com.raichess.domain.model.EloCalculator
 import com.raichess.domain.model.EloStats
-import com.raichess.domain.model.GameMode
-import com.raichess.domain.model.PlayerColor
 import com.raichess.ui.components.RaiLogo
+import com.raichess.ui.components.SectionLabel
 import com.raichess.ui.theme.ChessColors
-import kotlin.math.roundToInt
 
 /**
- * Home / new-game setup screen: brand lockup, player rating summary, opponent
- * strength selection, game mode, color choice, and start button.
+ * Home launcher: brand lockup, rating hero, and a quad of destination
+ * tiles (Play / Train / Coach / Review) with a Settings row beneath.
+ * Game setup lives in PlaySetupScreen; toggles and diagnostics live in
+ * SettingsScreen — home stays minimal on purpose.
  */
 @Composable
 fun HomeScreen(
     stats: EloStats?,
-    opponentElo: Int,
-    playerColor: PlayerColor,
-    gameMode: GameMode,
-    animationsEnabled: Boolean,
-    onOpponentEloChanged: (Int) -> Unit,
-    onPlayerColorChanged: (PlayerColor) -> Unit,
-    onGameModeChanged: (GameMode) -> Unit,
-    onAnimationsChanged: (Boolean) -> Unit,
-    onStartGame: (randomColor: Boolean) -> Unit,
-    onPractice: () -> Unit = {},
-    onReview: () -> Unit = {}
+    /** Coach tile subtitle — the coach's current headline, when loaded. */
+    coachLine: String?,
+    onPlay: () -> Unit,
+    onTrain: () -> Unit,
+    onCoach: () -> Unit,
+    onReview: () -> Unit,
+    onSettings: () -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -82,8 +55,8 @@ fun HomeScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         // Brand lockup
-        RaiLogo(size = 74.dp)
-        Spacer(modifier = Modifier.height(14.dp))
+        RaiLogo(size = 64.dp)
+        Spacer(modifier = Modifier.height(12.dp))
         Text(
             text = "RAICHESS",
             fontSize = 22.sp,
@@ -99,9 +72,9 @@ fun HomeScreen(
             modifier = Modifier.padding(top = 4.dp)
         )
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(28.dp))
 
-        // Rating hero
+        // Rating hero — compact; the full record lives in Settings
         if (stats != null) {
             Text(
                 text = "${stats.currentElo}",
@@ -114,14 +87,6 @@ fun HomeScreen(
                 text = "Your rating$confidence",
                 modifier = Modifier.padding(top = 6.dp)
             )
-            Spacer(modifier = Modifier.height(16.dp))
-            RecordRow(
-                wins = stats.wins,
-                draws = stats.draws,
-                losses = stats.losses
-            )
-            // Positive progress framing: personal best and streak, not a
-            // running tally of mistakes (undos stay tracked internally)
             if (stats.gamesPlayed > 0) {
                 val progressBits = buildList {
                     add("Peak ${stats.peakElo}")
@@ -136,144 +101,53 @@ fun HomeScreen(
             }
         }
 
-        Spacer(modifier = Modifier.height(30.dp))
+        Spacer(modifier = Modifier.height(28.dp))
 
-        // Mode
-        Section(label = "Mode") {
-            SegmentedControl(
-                options = listOf("Rated", "Training"),
-                selectedIndex = if (gameMode == GameMode.TRAINING) 1 else 0,
-                onSelect = { onGameModeChanged(if (it == 1) GameMode.TRAINING else GameMode.RATED) }
-            )
-            Text(
-                text = if (gameMode == GameMode.TRAINING) {
-                    "Undo and hints allowed — each use shrinks ELO gains"
-                } else {
-                    "No takebacks — full ELO stakes"
-                },
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier.padding(top = 10.dp)
-            )
-        }
-
-        Spacer(modifier = Modifier.height(26.dp))
-
-        // Opponent strength
-        Section(label = "Opponent") {
-            Text(
-                text = "$opponentElo ELO",
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onBackground
-            )
-            Slider(
-                value = opponentElo.toFloat(),
-                onValueChange = { onOpponentEloChanged((it / 50f).roundToInt() * 50) },
-                valueRange = RaiEngine.MIN_ELO.toFloat()..RaiEngine.MAX_ELO.toFloat(),
-                colors = SliderDefaults.colors(
-                    thumbColor = ChessColors.ControlActive,
-                    activeTrackColor = ChessColors.ControlActive,
-                    inactiveTrackColor = ChessColors.SliderInactiveTrack
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 4.dp)
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                TickLabel("${RaiEngine.MIN_ELO}")
-                TickLabel("1600")
-                TickLabel("${RaiEngine.MAX_ELO}")
-            }
-            // During placement the opponent auto-tracks the fast-moving
-            // provisional rating after each game (manual picks still apply
-            // to the next game only)
-            if (stats != null && stats.gamesPlayed < EloCalculator.PROVISIONAL_GAMES) {
-                Text(
-                    text = "Calibrating (game ${stats.gamesPlayed + 1} of " +
-                        "${EloCalculator.PROVISIONAL_GAMES}): the opponent adapts " +
-                        "to your results",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
-                    modifier = Modifier.padding(top = 10.dp)
-                )
-            }
-        }
-
-        Spacer(modifier = Modifier.height(26.dp))
-
-        // Color
-        Section(label = "Play as") {
-            SegmentedControl(
-                options = listOf("White ♔", "Black ♚"),
-                selectedIndex = if (playerColor == PlayerColor.BLACK) 1 else 0,
-                onSelect = {
-                    onPlayerColorChanged(if (it == 1) PlayerColor.BLACK else PlayerColor.WHITE)
-                }
-            )
-        }
-
-        Spacer(modifier = Modifier.height(26.dp))
-
-        // Animation toggle
+        // Destination quad
         Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Column {
-                SectionLabel(text = "Move animation")
-                Text(
-                    text = "150 ms slide · on by default",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
-                    modifier = Modifier.padding(top = 4.dp)
-                )
-            }
-            Switch(
-                checked = animationsEnabled,
-                onCheckedChange = onAnimationsChanged,
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = ChessColors.ControlActive,
-                    checkedTrackColor = ChessColors.ControlTrackActive,
-                    uncheckedThumbColor = ChessColors.ControlThumbInactive,
-                    uncheckedTrackColor = ChessColors.ControlTrackInactive
-                )
+            HomeTile(
+                glyph = "♟",
+                title = "Play",
+                subtitle = "A game at your level",
+                onClick = onPlay,
+                modifier = Modifier.weight(1f)
+            )
+            HomeTile(
+                glyph = "♞",
+                title = "Train",
+                subtitle = "Puzzles & drills",
+                onClick = onTrain,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            HomeTile(
+                glyph = "来",
+                title = "Coach",
+                subtitle = coachLine ?: "Your plan & focus",
+                onClick = onCoach,
+                modifier = Modifier.weight(1f)
+            )
+            HomeTile(
+                glyph = "♜",
+                title = "Review",
+                subtitle = "Browse past games",
+                onClick = onReview,
+                modifier = Modifier.weight(1f)
             )
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(12.dp))
 
-        Button(
-            onClick = { onStartGame(false) },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Start Game")
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        OutlinedButton(
-            onClick = { onStartGame(true) },
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Random Color")
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        OutlinedButton(
-            onClick = onPractice,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Practice")
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        OutlinedButton(
-            onClick = onReview,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Games & Review")
-        }
+        // Settings row tile
+        SettingsTile(onClick = onSettings)
 
         Spacer(modifier = Modifier.height(20.dp))
         // Visible build marker so it's unambiguous which APK is installed.
@@ -283,212 +157,84 @@ fun HomeScreen(
             letterSpacing = 1.sp,
             color = MaterialTheme.colorScheme.secondary
         )
-        EngineLogRow()
     }
 }
 
-/**
- * Deliberately shipped in ALL builds, not gated behind BuildConfig.DEBUG:
- * the point is that a player in the field can self-diagnose "why did my
- * game fall back to RaiEngine?" from the device, without logcat. Opens
- * the persisted engine event log (see EngineDiagnostics).
- */
+/** One square destination tile: big glyph, title, short subtitle. */
 @Composable
-private fun EngineLogRow() {
-    var showLog by remember { mutableStateOf(false) }
-    TextButton(onClick = { showLog = true }) {
-        Text(
-            text = "Engine log",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.secondary
-        )
-    }
-    if (showLog) {
-        val context = LocalContext.current
-        val clipboard = LocalClipboardManager.current
-        // Stored oldest-first; displayed newest-first (the event being
-        // debugged is usually the last one), copied chronologically
-        val stored = remember { EngineDiagnostics.entries(context) }
-        val entries = remember(stored) { stored.reversed() }
-        AlertDialog(
-            onDismissRequest = { showLog = false },
-            title = { Text("Engine log") },
-            text = {
-                Column(
-                    modifier = Modifier
-                        .heightIn(max = 400.dp)
-                        .verticalScroll(rememberScrollState())
-                ) {
-                    if (entries.isEmpty()) {
-                        Text(
-                            "No engine events recorded yet.",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    } else {
-                        Text(
-                            "Tap a line to copy it.",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.secondary,
-                            modifier = Modifier.padding(bottom = 4.dp)
-                        )
-                    }
-                    entries.forEach { entry ->
-                        Text(
-                            text = entry,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier
-                                .clickable { clipboard.setText(AnnotatedString(entry)) }
-                                .padding(vertical = 2.dp)
-                        )
-                    }
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = { showLog = false }) { Text("Close") }
-            },
-            dismissButton = {
-                Row {
-                    TextButton(onClick = {
-                        clipboard.setText(AnnotatedString(stored.joinToString("\n")))
-                    }) { Text("Copy all") }
-                    TextButton(onClick = {
-                        EngineDiagnostics.clear(context)
-                        showLog = false
-                    }) { Text("Clear") }
-                }
-            }
-        )
-    }
-}
-
-/** A labelled section: an uppercase eyebrow above its content. */
-@Composable
-private fun Section(label: String, content: @Composable () -> Unit) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        SectionLabel(text = label, modifier = Modifier.padding(bottom = 11.dp))
-        content()
-    }
-}
-
-/** Uppercase, wide-tracked eyebrow label. */
-@Composable
-private fun SectionLabel(text: String, modifier: Modifier = Modifier) {
-    Text(
-        text = text.uppercase(),
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.secondary,
-        letterSpacing = 2.sp,
-        modifier = modifier
-    )
-}
-
-@Composable
-private fun TickLabel(text: String) {
-    Text(
-        text = text,
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.secondary
-    )
-}
-
-/** Two-or-more option segmented control; the selected cell is filled. */
-@Composable
-private fun SegmentedControl(
-    options: List<String>,
-    selectedIndex: Int,
-    onSelect: (Int) -> Unit,
+private fun HomeTile(
+    glyph: String,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val shape = RoundedCornerShape(12.dp)
-    Row(
+    val shape = RoundedCornerShape(16.dp)
+    Column(
         modifier = modifier
-            .fillMaxWidth()
-            .height(IntrinsicSize.Min)
+            .aspectRatio(1f)
             .clip(shape)
             .border(1.dp, ChessColors.SquareBorder.copy(alpha = 0.35f), shape)
+            .clickable(onClick = onClick)
+            .padding(14.dp),
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
-        options.forEachIndexed { index, label ->
-            if (index > 0) {
-                Box(
-                    modifier = Modifier
-                        .width(1.dp)
-                        .fillMaxHeight()
-                        .background(ChessColors.SquareBorder.copy(alpha = 0.35f))
-                )
-            }
-            val selected = index == selectedIndex
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .background(if (selected) ChessColors.ControlActive else Color.Transparent)
-                    .clickable { onSelect(index) }
-                    .padding(vertical = 12.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = label,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = if (selected) FontWeight.Medium else FontWeight.Normal,
-                    color = if (selected) Color.Black else MaterialTheme.colorScheme.secondary
-                )
-            }
+        Text(
+            text = glyph,
+            fontSize = 30.sp,
+            color = MaterialTheme.colorScheme.secondary
+        )
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 2.dp)
+            )
         }
     }
 }
 
-/** Framed Won / Drew / Lost record. */
+/** Full-width bottom row tile for settings. */
 @Composable
-private fun RecordRow(
-    wins: Int,
-    draws: Int,
-    losses: Int,
-    modifier: Modifier = Modifier
-) {
-    val line = ChessColors.SquareBorder.copy(alpha = 0.35f)
-    val shape = RoundedCornerShape(12.dp)
+private fun SettingsTile(onClick: () -> Unit) {
+    val shape = RoundedCornerShape(16.dp)
     Row(
-        modifier = modifier
+        modifier = Modifier
             .fillMaxWidth()
-            .height(IntrinsicSize.Min)
             .clip(shape)
-            .border(1.dp, line, shape)
+            .border(1.dp, ChessColors.SquareBorder.copy(alpha = 0.35f), shape)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        RecordCell(label = "Won", value = wins, modifier = Modifier.weight(1f))
-        Box(
-            modifier = Modifier
-                .width(1.dp)
-                .fillMaxHeight()
-                .background(line)
-        )
-        RecordCell(label = "Drew", value = draws, modifier = Modifier.weight(1f))
-        Box(
-            modifier = Modifier
-                .width(1.dp)
-                .fillMaxHeight()
-                .background(line)
-        )
-        RecordCell(label = "Lost", value = losses, modifier = Modifier.weight(1f))
-    }
-}
-
-@Composable
-private fun RecordCell(label: String, value: Int, modifier: Modifier = Modifier) {
-    Column(
-        modifier = modifier.padding(vertical = 11.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+        Column {
+            Text(
+                text = "Settings",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Text(
+                text = "Stats · animations · engine log",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
         Text(
-            text = "$value",
-            fontSize = 18.sp,
-            fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onBackground
-        )
-        Text(
-            text = label.uppercase(),
-            style = MaterialTheme.typography.labelSmall,
-            letterSpacing = 1.5.sp,
-            color = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier.padding(top = 3.dp)
+            text = "⚙",
+            fontSize = 22.sp,
+            color = MaterialTheme.colorScheme.secondary
         )
     }
 }

--- a/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.raichess.BuildConfig
 import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.GameMode
 import com.raichess.ui.components.RaiLogo
 import com.raichess.ui.components.SectionLabel
 import com.raichess.ui.theme.ChessColors
@@ -33,15 +34,21 @@ import com.raichess.ui.theme.ChessColors
 /**
  * Home launcher: brand lockup, rating hero, and a quad of destination
  * tiles (Play / Train / Coach / Review) with a Settings row beneath.
- * Game setup lives in PlaySetupScreen; toggles and diagnostics live in
- * SettingsScreen — home stays minimal on purpose.
+ * The Play tile starts a game immediately with the current setup (shown
+ * in its subtitle); its corner "custom" button opens PlaySetupScreen.
+ * Toggles and diagnostics live in SettingsScreen — home stays minimal
+ * on purpose.
  */
 @Composable
 fun HomeScreen(
     stats: EloStats?,
     /** Coach tile subtitle — the coach's current headline, when loaded. */
     coachLine: String?,
+    /** Current setup, shown on the Play tile so one-tap play is no surprise. */
+    opponentElo: Int,
+    gameMode: GameMode,
     onPlay: () -> Unit,
+    onCustomizeGame: () -> Unit,
     onTrain: () -> Unit,
     onCoach: () -> Unit,
     onReview: () -> Unit,
@@ -111,8 +118,11 @@ fun HomeScreen(
             HomeTile(
                 glyph = "♟",
                 title = "Play",
-                subtitle = "A game at your level",
+                subtitle = "vs $opponentElo · " +
+                    if (gameMode == GameMode.TRAINING) "Training" else "Rated",
                 onClick = onPlay,
+                cornerLabel = "CUSTOM",
+                onCornerClick = onCustomizeGame,
                 modifier = Modifier.weight(1f)
             )
             HomeTile(
@@ -160,14 +170,20 @@ fun HomeScreen(
     }
 }
 
-/** One square destination tile: big glyph, title, short subtitle. */
+/**
+ * One square destination tile: big glyph, title, short subtitle. The
+ * optional corner label is a small secondary action (its own tap target,
+ * nested inside the tile's) — used by Play for "customize this game".
+ */
 @Composable
 private fun HomeTile(
     glyph: String,
     title: String,
     subtitle: String,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    cornerLabel: String? = null,
+    onCornerClick: (() -> Unit)? = null
 ) {
     val shape = RoundedCornerShape(16.dp)
     Column(
@@ -179,11 +195,29 @@ private fun HomeTile(
             .padding(14.dp),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
-        Text(
-            text = glyph,
-            fontSize = 30.sp,
-            color = MaterialTheme.colorScheme.secondary
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.Top
+        ) {
+            Text(
+                text = glyph,
+                fontSize = 30.sp,
+                color = MaterialTheme.colorScheme.secondary
+            )
+            if (cornerLabel != null && onCornerClick != null) {
+                Text(
+                    text = cornerLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    letterSpacing = 1.sp,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .clickable(onClick = onCornerClick)
+                        .padding(horizontal = 6.dp, vertical = 4.dp)
+                )
+            }
+        }
         Column {
             Text(
                 text = title,

--- a/app/src/main/java/com/raichess/ui/home/PlaySetupScreen.kt
+++ b/app/src/main/java/com/raichess/ui/home/PlaySetupScreen.kt
@@ -1,0 +1,177 @@
+package com.raichess.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.raichess.data.engine.RaiEngine
+import com.raichess.domain.model.EloCalculator
+import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.GameMode
+import com.raichess.domain.model.PlayerColor
+import com.raichess.ui.components.Section
+import com.raichess.ui.components.SegmentedControl
+import com.raichess.ui.components.TickLabel
+import com.raichess.ui.theme.ChessColors
+import kotlin.math.roundToInt
+
+/**
+ * Game setup: mode, opponent strength, color, and start buttons. Split
+ * out of the home screen when it became a launcher — this is what the
+ * Play tile opens.
+ */
+@Composable
+fun PlaySetupScreen(
+    stats: EloStats?,
+    opponentElo: Int,
+    playerColor: PlayerColor,
+    gameMode: GameMode,
+    onOpponentEloChanged: (Int) -> Unit,
+    onPlayerColorChanged: (PlayerColor) -> Unit,
+    onGameModeChanged: (GameMode) -> Unit,
+    onStartGame: (randomColor: Boolean) -> Unit,
+    onBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 28.dp, vertical = 40.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Play",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        if (stats != null) {
+            Text(
+                text = "You: ${stats.currentElo}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        // Mode
+        Section(label = "Mode") {
+            SegmentedControl(
+                options = listOf("Rated", "Training"),
+                selectedIndex = if (gameMode == GameMode.TRAINING) 1 else 0,
+                onSelect = { onGameModeChanged(if (it == 1) GameMode.TRAINING else GameMode.RATED) }
+            )
+            Text(
+                text = if (gameMode == GameMode.TRAINING) {
+                    "Undo and hints allowed — each use shrinks ELO gains"
+                } else {
+                    "No takebacks — full ELO stakes"
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier.padding(top = 10.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(26.dp))
+
+        // Opponent strength
+        Section(label = "Opponent") {
+            Text(
+                text = "$opponentElo ELO",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            Slider(
+                value = opponentElo.toFloat(),
+                onValueChange = { onOpponentEloChanged((it / 50f).roundToInt() * 50) },
+                valueRange = RaiEngine.MIN_ELO.toFloat()..RaiEngine.MAX_ELO.toFloat(),
+                colors = SliderDefaults.colors(
+                    thumbColor = ChessColors.ControlActive,
+                    activeTrackColor = ChessColors.ControlActive,
+                    inactiveTrackColor = ChessColors.SliderInactiveTrack
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp)
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                TickLabel("${RaiEngine.MIN_ELO}")
+                TickLabel("1600")
+                TickLabel("${RaiEngine.MAX_ELO}")
+            }
+            // During placement the opponent auto-tracks the fast-moving
+            // provisional rating after each game (manual picks still apply
+            // to the next game only)
+            if (stats != null && stats.gamesPlayed < EloCalculator.PROVISIONAL_GAMES) {
+                Text(
+                    text = "Calibrating (game ${stats.gamesPlayed + 1} of " +
+                        "${EloCalculator.PROVISIONAL_GAMES}): the opponent adapts " +
+                        "to your results",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.padding(top = 10.dp)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(26.dp))
+
+        // Color
+        Section(label = "Play as") {
+            SegmentedControl(
+                options = listOf("White ♔", "Black ♚"),
+                selectedIndex = if (playerColor == PlayerColor.BLACK) 1 else 0,
+                onSelect = {
+                    onPlayerColorChanged(if (it == 1) PlayerColor.BLACK else PlayerColor.WHITE)
+                }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = { onStartGame(false) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Start Game")
+        }
+        Spacer(modifier = Modifier.height(10.dp))
+        OutlinedButton(
+            onClick = { onStartGame(true) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Random Color")
+        }
+        Spacer(modifier = Modifier.height(10.dp))
+        OutlinedButton(
+            onClick = onBack,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Back")
+        }
+    }
+}

--- a/app/src/main/java/com/raichess/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/raichess/ui/settings/SettingsScreen.kt
@@ -1,0 +1,213 @@
+package com.raichess.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.raichess.BuildConfig
+import com.raichess.data.diagnostics.EngineDiagnostics
+import com.raichess.domain.model.EloStats
+import com.raichess.ui.components.RecordRow
+import com.raichess.ui.components.Section
+import com.raichess.ui.components.SectionLabel
+import com.raichess.ui.theme.ChessColors
+
+/**
+ * Settings & stats: the full game record, preference toggles, and the
+ * engine diagnostics log. Everything the launcher home deliberately
+ * doesn't show lives here.
+ */
+@Composable
+fun SettingsScreen(
+    stats: EloStats?,
+    animationsEnabled: Boolean,
+    onAnimationsChanged: (Boolean) -> Unit,
+    onBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 28.dp, vertical = 40.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Settings",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        if (stats != null) {
+            Section(label = "Record") {
+                RecordRow(
+                    wins = stats.wins,
+                    draws = stats.draws,
+                    losses = stats.losses
+                )
+                val bits = buildList {
+                    add("${stats.gamesPlayed} games")
+                    add("Peak ${stats.peakElo}")
+                    if (stats.winStreak >= 2) add("${stats.winStreak}-game win streak")
+                    if (stats.confidenceInterval > 0) add("±${stats.confidenceInterval} confidence")
+                }
+                Text(
+                    text = bits.joinToString("  ·  "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.padding(top = 10.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(26.dp))
+        }
+
+        // Animation toggle
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column {
+                SectionLabel(text = "Move animation")
+                Text(
+                    text = "150 ms slide · on by default",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+            Switch(
+                checked = animationsEnabled,
+                onCheckedChange = onAnimationsChanged,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = ChessColors.ControlActive,
+                    checkedTrackColor = ChessColors.ControlTrackActive,
+                    uncheckedThumbColor = ChessColors.ControlThumbInactive,
+                    uncheckedTrackColor = ChessColors.ControlTrackInactive
+                )
+            )
+        }
+
+        Spacer(modifier = Modifier.height(26.dp))
+
+        EngineLogRow()
+
+        Spacer(modifier = Modifier.height(20.dp))
+        Text(
+            text = "v${BuildConfig.VERSION_NAME}",
+            style = MaterialTheme.typography.labelSmall,
+            letterSpacing = 1.sp,
+            color = MaterialTheme.colorScheme.secondary
+        )
+
+        Spacer(modifier = Modifier.height(28.dp))
+        OutlinedButton(
+            onClick = onBack,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Back")
+        }
+    }
+}
+
+/**
+ * Deliberately shipped in ALL builds, not gated behind BuildConfig.DEBUG:
+ * the point is that a player in the field can self-diagnose "why did my
+ * game fall back to RaiEngine?" from the device, without logcat. Opens
+ * the persisted engine event log (see EngineDiagnostics).
+ */
+@Composable
+private fun EngineLogRow() {
+    var showLog by remember { mutableStateOf(false) }
+    TextButton(onClick = { showLog = true }) {
+        Text(
+            text = "Engine log",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.secondary
+        )
+    }
+    if (showLog) {
+        val context = LocalContext.current
+        val clipboard = LocalClipboardManager.current
+        // Stored oldest-first; displayed newest-first (the event being
+        // debugged is usually the last one), copied chronologically
+        val stored = remember { EngineDiagnostics.entries(context) }
+        val entries = remember(stored) { stored.reversed() }
+        AlertDialog(
+            onDismissRequest = { showLog = false },
+            title = { Text("Engine log") },
+            text = {
+                Column(
+                    modifier = Modifier
+                        .heightIn(max = 400.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    if (entries.isEmpty()) {
+                        Text(
+                            "No engine events recorded yet.",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    } else {
+                        Text(
+                            "Tap a line to copy it.",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.secondary,
+                            modifier = Modifier.padding(bottom = 4.dp)
+                        )
+                    }
+                    entries.forEach { entry ->
+                        Text(
+                            text = entry,
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier
+                                .clickable { clipboard.setText(AnnotatedString(entry)) }
+                                .padding(vertical = 2.dp)
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showLog = false }) { Text("Close") }
+            },
+            dismissButton = {
+                Row {
+                    TextButton(onClick = {
+                        clipboard.setText(AnnotatedString(stored.joinToString("\n")))
+                    }) { Text("Copy all") }
+                    TextButton(onClick = {
+                        EngineDiagnostics.clear(context)
+                        showLog = false
+                    }) { Text("Clear") }
+                }
+            }
+        )
+    }
+}

--- a/app/src/test/java/com/raichess/calibration/RaiEngineCalibrationTest.kt
+++ b/app/src/test/java/com/raichess/calibration/RaiEngineCalibrationTest.kt
@@ -1,0 +1,145 @@
+package com.raichess.calibration
+
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.Side
+import com.github.bhlangonijr.chesslib.move.MoveGenerator
+import com.raichess.data.engine.RaiEngine
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import kotlin.math.log10
+import kotlin.math.roundToInt
+import kotlin.random.Random
+
+/**
+ * Cross-validates RaiEngine's heuristic ELO labels by playing each band
+ * against a real Stockfish limited to known UCI_Elo anchor strengths, then
+ * converting the match score into an implied rating with the ELO formula
+ * (impliedDiff = -400 * log10(1/score - 1)).
+ *
+ * This is a measurement, not a pass/fail gate: it prints a report and only
+ * asserts that games actually completed. It is OFF by default — a normal
+ * `testDebugUnitTest` run skips it via the Assume gate — and runs on demand
+ * through the calibrate-raiengine workflow (or locally with
+ * `-Draichess.calibrate=true -Dstockfish.path=$(command -v stockfish)`),
+ * because it needs a desktop Stockfish binary and several minutes of match
+ * play. See build.gradle.kts testOptions for the property passthrough.
+ */
+class RaiEngineCalibrationTest {
+
+    @Test
+    fun `measure implied elo of each raiengine band against stockfish anchors`() {
+        assumeTrue(
+            "calibration is opt-in: run with -Draichess.calibrate=true",
+            System.getProperty("raichess.calibrate") == "true"
+        )
+        val stockfishPath = System.getProperty("stockfish.path") ?: "stockfish"
+        val gamesPerPairing =
+            (System.getProperty("raichess.calibrate.games") ?: "$DEFAULT_GAMES").toInt()
+
+        val report = StringBuilder()
+        report.appendLine("RaiEngine calibration vs Stockfish ($stockfishPath)")
+        report.appendLine("band | anchor | games | score | implied ELO")
+        report.appendLine("-----+--------+-------+-------+------------")
+
+        var totalGames = 0
+        for (band in BANDS) {
+            for (anchor in ANCHORS) {
+                UciProcessClient(stockfishPath).use { stockfish ->
+                    stockfish.startLimitedTo(anchor)
+                    var score = 0.0
+                    for (game in 0 until gamesPerPairing) {
+                        // Seeded per game: reruns reproduce the same matches
+                        val rai = RaiEngine(
+                            targetElo = band,
+                            random = Random(band * 10_000 + anchor + game)
+                        )
+                        score += playGame(rai, stockfish, raiIsWhite = game % 2 == 0)
+                        totalGames++
+                    }
+                    val fraction = score / gamesPerPairing
+                    report.appendLine(
+                        "%4d | %6d | %5d | %.3f | %11s".format(
+                            band, anchor, gamesPerPairing, fraction,
+                            impliedEloText(anchor, fraction)
+                        )
+                    )
+                }
+            }
+        }
+
+        report.appendLine()
+        report.appendLine(
+            "Implied ELO outside [anchor-$MAX_MEASURABLE_DIFF, anchor+$MAX_MEASURABLE_DIFF] " +
+                "saturates the formula (near 0%/100% scores) and reads as a bound, not a value."
+        )
+        println(report)
+        assert(totalGames == BANDS.size * ANCHORS.size * gamesPerPairing)
+    }
+
+    /**
+     * One game between [rai] and [stockfish]; returns RaiEngine's score
+     * (1 win / 0.5 draw / 0 loss). Games hitting [MAX_PLIES] are adjudicated
+     * as draws — with these settings that is rare and slightly favours the
+     * weaker side, which for label validation is the conservative direction.
+     */
+    private fun playGame(
+        rai: RaiEngine,
+        stockfish: UciProcessClient,
+        raiIsWhite: Boolean
+    ): Double {
+        val board = Board()
+        stockfish.newGame()
+        var plies = 0
+        while (plies < MAX_PLIES) {
+            if (board.isMated) {
+                val raiToMove = (board.sideToMove == Side.WHITE) == raiIsWhite
+                return if (raiToMove) 0.0 else 1.0
+            }
+            if (board.isDraw) return 0.5
+
+            val raiToMove = (board.sideToMove == Side.WHITE) == raiIsWhite
+            val move = if (raiToMove) {
+                rai.selectMove(board) ?: return 0.5 // unreachable after the checks above
+            } else {
+                val lan = stockfish.bestMove(board.fen, SF_MOVE_TIME_MS) ?: return 0.5
+                MoveGenerator.generateLegalMoves(board)
+                    .firstOrNull { it.toString().lowercase() == lan }
+                    ?: error("stockfish played illegal move $lan in ${board.fen}")
+            }
+            board.doMove(move)
+            plies++
+        }
+        return 0.5
+    }
+
+    /** Match score -> implied rating; clamped so a shutout stays finite. */
+    private fun impliedEloText(anchor: Int, fraction: Double): String {
+        val clamped = fraction.coerceIn(CLAMP_MIN, 1.0 - CLAMP_MIN)
+        val implied = anchor + (-400.0 * log10(1.0 / clamped - 1.0)).roundToInt()
+        return when {
+            fraction <= CLAMP_MIN -> "<= $implied"
+            fraction >= 1.0 - CLAMP_MIN -> ">= $implied"
+            else -> "$implied"
+        }
+    }
+
+    companion object {
+        // The RaiEngine band the app actually serves (below EngineFactory's
+        // 1350 Stockfish floor), sampled at its curve breakpoints
+        private val BANDS = intArrayOf(600, 800, 1000, 1100, 1300)
+
+        // 1320 is modern Stockfish's UCI_Elo floor; 1500 gives a second
+        // reference point so the two implied ratings can sanity-check each
+        // other (both should land near the same value for a given band)
+        private val ANCHORS = intArrayOf(1320, 1500)
+
+        private const val DEFAULT_GAMES = 12
+        private const val SF_MOVE_TIME_MS = 60L
+        private const val MAX_PLIES = 240
+
+        // Score clamp for the implied-ELO formula; 0.02 caps the measurable
+        // difference at ~676 points either side of the anchor
+        private const val CLAMP_MIN = 0.02
+        private const val MAX_MEASURABLE_DIFF = 676
+    }
+}

--- a/app/src/test/java/com/raichess/calibration/UciProcessClient.kt
+++ b/app/src/test/java/com/raichess/calibration/UciProcessClient.kt
@@ -1,0 +1,67 @@
+package com.raichess.calibration
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Minimal blocking UCI client over a local engine process, used only by the
+ * opt-in calibration harness ([RaiEngineCalibrationTest]) — the app itself
+ * never spawns desktop processes. Single-threaded by design: every command
+ * waits for its reply before the next is sent.
+ */
+class UciProcessClient(enginePath: String) : AutoCloseable {
+
+    private val process = ProcessBuilder(enginePath)
+        .redirectErrorStream(true)
+        .start()
+    private val writer = process.outputStream.bufferedWriter()
+    private val reader = process.inputStream.bufferedReader()
+
+    /**
+     * UCI handshake plus strength limiting to [elo] via UCI_Elo (supported
+     * by Stockfish 11+; modern builds floor at 1320).
+     */
+    fun startLimitedTo(elo: Int) {
+        send("uci")
+        waitFor("uciok")
+        send("setoption name UCI_LimitStrength value true")
+        send("setoption name UCI_Elo value $elo")
+        send("isready")
+        waitFor("readyok")
+    }
+
+    fun newGame() {
+        send("ucinewgame")
+        send("isready")
+        waitFor("readyok")
+    }
+
+    /**
+     * Search [fen] for [moveTimeMs] and return the chosen move in lowercase
+     * LAN, or null when the engine has no move (mate/stalemate).
+     */
+    fun bestMove(fen: String, moveTimeMs: Long): String? {
+        send("position fen $fen")
+        send("go movetime $moveTimeMs")
+        val line = waitFor("bestmove")
+        return line.split(" ").getOrNull(1)?.lowercase()?.takeIf { it != "(none)" }
+    }
+
+    private fun send(command: String) {
+        writer.write(command)
+        writer.newLine()
+        writer.flush()
+    }
+
+    private fun waitFor(prefix: String): String {
+        while (true) {
+            val line = reader.readLine()
+                ?: error("engine process ended while waiting for '$prefix'")
+            if (line.startsWith(prefix)) return line
+        }
+    }
+
+    override fun close() {
+        runCatching { send("quit") }
+        if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly()
+    }
+}

--- a/app/src/test/java/com/raichess/domain/model/EloCalculatorTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/EloCalculatorTest.kt
@@ -147,6 +147,43 @@ class EloCalculatorTest {
         assertEquals(675, newElo)
     }
 
+    @Test
+    fun `assisted gain factor scales down and floors at zero`() {
+        assertEquals(1.0, EloCalculator.assistedGainFactor(0), 0.001)
+        assertEquals(0.8, EloCalculator.assistedGainFactor(1), 0.001)
+        assertEquals(0.6, EloCalculator.assistedGainFactor(2), 0.001)
+        assertEquals(0.0, EloCalculator.assistedGainFactor(5), 0.001)
+        assertEquals(0.0, EloCalculator.assistedGainFactor(20), 0.001)
+    }
+
+    @Test
+    fun `assistance shrinks a win's gain and five assists erase it`() {
+        val clean = EloCalculator.calculateNewElo(
+            1200, 1200, GameResult.WIN, 50.0, assistedMoves = 0
+        )
+        val helped = EloCalculator.calculateNewElo(
+            1200, 1200, GameResult.WIN, 50.0, assistedMoves = 2
+        )
+        val carried = EloCalculator.calculateNewElo(
+            1200, 1200, GameResult.WIN, 50.0, assistedMoves = 5
+        )
+        assertTrue("clean win should out-gain assisted win", clean > helped)
+        assertTrue("assisted win should still gain a little", helped > 1200)
+        assertEquals("5 assists should zero the gain", 1200, carried)
+    }
+
+    @Test
+    fun `assistance never softens a loss`() {
+        val cleanLoss = EloCalculator.calculateNewElo(
+            1200, 1200, GameResult.LOSS, 50.0, assistedMoves = 0
+        )
+        val helpedLoss = EloCalculator.calculateNewElo(
+            1200, 1200, GameResult.LOSS, 50.0, assistedMoves = 5
+        )
+        assertEquals("losses cost full price regardless of assists", cleanLoss, helpedLoss)
+        assertTrue(cleanLoss < 1200)
+    }
+
     @org.junit.Test
     fun `win streak increments on wins, holds on draws, resets on losses`() {
         val stats = EloStats(

--- a/app/src/test/java/com/raichess/domain/usecase/CoachAdvisorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/CoachAdvisorTest.kt
@@ -1,0 +1,99 @@
+package com.raichess.domain.usecase
+
+import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.ThemeTag
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CoachAdvisorTest {
+
+    private fun stats(
+        gamesPlayed: Int,
+        winStreak: Int = 0
+    ) = EloStats(
+        currentElo = 800, peakElo = 850, gamesPlayed = gamesPlayed,
+        wins = gamesPlayed, losses = 0, draws = 0,
+        confidenceInterval = 100, winStreak = winStreak
+    )
+
+    private fun themeStat(theme: ThemeTag, occurrences: Int = 4, avgLossCp: Double = 250.0) =
+        ThemeStat(theme = theme, score = 2.0, occurrences = occurrences, avgLossCp = avgLossCp)
+
+    private val defaultPlan = LessonPlanner.buildPlan(WeaknessProfile.EMPTY)
+
+    @Test
+    fun `no games yet gets a welcome and a play action`() {
+        val advice = CoachAdvisor.advise(null, WeaknessProfile.EMPTY, defaultPlan, emptyMap())
+        assertTrue(advice.headline.contains("Welcome"))
+        assertEquals(CoachAdvisor.Action.PLAY_GAME, advice.action)
+        assertTrue(advice.focuses.isNotEmpty())
+    }
+
+    @Test
+    fun `top weakness leads the talking points`() {
+        val profile = WeaknessProfile(
+            weaknesses = listOf(themeStat(ThemeTag.HANGING_PIECE)),
+            phases = listOf(themeStat(ThemeTag.ENDGAME))
+        )
+        val advice = CoachAdvisor.advise(stats(15), profile, defaultPlan, emptyMap())
+        assertEquals("Let's keep your pieces safe.", advice.headline)
+        assertTrue("detail should cite the count, got: ${advice.detail}",
+            advice.detail.contains("4×"))
+        // The phase still gets airtime as a secondary focus
+        assertTrue(advice.focuses.any { it.contains("your endgames") })
+    }
+
+    @Test
+    fun `phase-only profile talks about the game stage`() {
+        val profile = WeaknessProfile(
+            weaknesses = emptyList(),
+            phases = listOf(themeStat(ThemeTag.OPENING))
+        )
+        val advice = CoachAdvisor.advise(stats(15), profile, defaultPlan, emptyMap())
+        assertTrue(advice.headline.contains("your openings"))
+    }
+
+    @Test
+    fun `calibration and streak surface as focuses`() {
+        val advice = CoachAdvisor.advise(
+            stats(gamesPlayed = 3, winStreak = 3), WeaknessProfile.EMPTY,
+            defaultPlan, emptyMap()
+        )
+        assertTrue(advice.focuses.any { it.contains("game 4 of") })
+        assertTrue(advice.focuses.any { it.contains("3 wins in a row") })
+    }
+
+    @Test
+    fun `active lesson drives the suggested action`() {
+        val advice = CoachAdvisor.advise(stats(15), WeaknessProfile.EMPTY, defaultPlan, emptyMap())
+        assertEquals(CoachAdvisor.Action.START_LESSON, advice.action)
+        assertTrue(advice.actionLabel.startsWith("Continue:"))
+        assertTrue(advice.focuses.any { it.startsWith("Current lesson:") })
+    }
+
+    @Test
+    fun `finished plan falls back to playing and says so`() {
+        val allSolved = defaultPlan.associate { it.id to it.targetSolves }
+        val advice = CoachAdvisor.advise(stats(15), WeaknessProfile.EMPTY, defaultPlan, allSolved)
+        assertEquals(CoachAdvisor.Action.PLAY_GAME, advice.action)
+        assertTrue(advice.focuses.any { it.contains("plan is complete") })
+    }
+
+    @Test
+    fun `clean profile stays encouraging`() {
+        val advice = CoachAdvisor.advise(stats(25), WeaknessProfile.EMPTY, defaultPlan, emptyMap())
+        assertEquals("Looking sharp.", advice.headline)
+    }
+
+    @Test
+    fun `single occurrence reads as once, not 1x`() {
+        val profile = WeaknessProfile(
+            weaknesses = listOf(themeStat(ThemeTag.MISSED_MATE, occurrences = 1)),
+            phases = emptyList()
+        )
+        val advice = CoachAdvisor.advise(stats(15), profile, defaultPlan, emptyMap())
+        assertTrue(advice.detail.contains("once"))
+        assertTrue(!advice.detail.contains("1×"))
+    }
+}


### PR DESCRIPTION
Two rounds of work on one branch (the first was still open when the second request came in):

# Round 1 — ELO integrity

## Assistance-gated rating gains

Each hint rung or undo in a Training game removes 20% of a **positive** rating change — 1 assist keeps 80% of the gain, 5+ keep nothing. Losses always cost full price, so assistance can never shield a rating, only stop it from being inflated. Stacks with the existing accuracy dock; even a provisional-K blowout win nets +0 if it was coach-carried.

- `EloCalculator.assistedGainFactor()` + `assistedMoves` param, wired `PlayerProfileRepository.recordResult` → `GameViewModel.finishGame` (Training only; Rated has no assists)
- 3 new `EloCalculatorTest` cases (18/18 pass)

## RaiEngine ELO cross-validation harness

`RaiEngineCalibrationTest` plays every band the app serves (600–1300) against a desktop Stockfish limited to known `UCI_Elo` anchors (1320 and 1500), converts match scores to implied ratings via `-400·log10(1/s − 1)`, and prints a table. Opt-in via `-Draichess.calibrate=true` (normal CI compiles it but skips it). New manual **Calibrate RaiEngine** workflow runs it on demand — it appears in the Actions tab once this lands on `main`. The `UciProcessClient` was verified locally against a real Stockfish 16.

# Round 2 — Quad-tile home + proactive coach

## Home as a minimal launcher

Rating hero + a 2×2 tile grid — **Play** (game setup, moved to its own screen), **Train** (puzzles & drills), **Coach** (new), **Review** (games browser) — with a full-width **Settings** row tile beneath. Settings now holds the full record, the animations toggle, and the engine log; game setup (mode / opponent slider / color / calibration hint) lives behind Play.

## Proactive, personal coach

New `CoachAdvisor` (pure, deterministic, 8 tests): turns the weakness profile, lesson plan, and rating state into the coach's own words —

- Headline + observation: *"Let's keep your pieces safe. Pieces keep getting left where they can be taken: I've counted it 4× in your recent games — costing about 2 pawns of position each time."*
- Phase talk when no substantive weakness leads: *"Let's work on your endgames."*
- Focus bullets: calibration progress, win streaks, current lesson progress, where mistakes cluster
- One suggested action: **Continue: <lesson>** (opens Practice already in the Lesson queue) or **Play a game**

The Coach screen shows the message, the action button, and the full lesson plan with per-unit progress (✓ done / ▸ active). The Coach tile on home carries the current headline as its subtitle, so the coach speaks before you even open it. First-run voice introduces itself ("Welcome — I'm Rai, your coach") and asks for a game or two to learn from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p