### PR TITLE
Expert-review fixes: back handling, post-game loop, navigation architecture

### DIFF
--- a/app/src/main/java/com/raichess/MainActivity.kt
+++ b/app/src/main/java/com/raichess/MainActivity.kt
@@ -2,15 +2,26 @@ package com.raichess
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -43,137 +54,139 @@ import com.raichess.ui.theme.RaiChessTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         // Finish any post-game analysis a previous process didn't complete
         // (fire-and-forget; no-op when nothing is pending)
         AnalysisCoordinator.analyzePendingGames(applicationContext)
         setContent {
             RaiChessTheme {
+                // The Surface paints the whole window (incl. behind the
+                // system bars) black; content itself stays inside the safe
+                // drawing insets so nothing hides under bars or the gesture
+                // nav pill
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    RaiChessApp()
+                    Box(
+                        modifier = Modifier.windowInsetsPadding(WindowInsets.safeDrawing)
+                    ) {
+                        RaiChessApp()
+                    }
                 }
             }
         }
     }
 }
 
+/**
+ * The app's destinations. Exactly one is active — replacing the previous
+ * pile of independent boolean flags whose priority depended on statement
+ * order. An active game (GamePhase != SETUP) overlays whatever screen is
+ * set; [Screen] is where the player returns when it ends.
+ */
+sealed interface Screen {
+    data object Home : Screen
+    data object PlaySetup : Screen
+    data class Practice(val openLesson: Boolean = false) : Screen
+    data object Coach : Screen
+    data object Games : Screen
+    data class Review(val gameId: Long) : Screen
+    data object Settings : Screen
+
+    companion object {
+        /** The just-finished game (still saving/analyzing) in [Review]. */
+        const val LATEST_GAME = -1L
+
+        /** Bundle codec for rememberSaveable. */
+        val Saver = listSaver<Screen, Any>(
+            save = { screen ->
+                when (screen) {
+                    Home -> listOf("home")
+                    PlaySetup -> listOf("play")
+                    is Practice -> listOf("practice", screen.openLesson)
+                    Coach -> listOf("coach")
+                    Games -> listOf("games")
+                    is Review -> listOf("review", screen.gameId)
+                    Settings -> listOf("settings")
+                }
+            },
+            restore = { saved ->
+                when (saved.firstOrNull()) {
+                    "play" -> PlaySetup
+                    "practice" -> Practice(saved.getOrNull(1) as? Boolean ?: false)
+                    "coach" -> Coach
+                    "games" -> Games
+                    "review" -> Review(saved.getOrNull(1) as? Long ?: LATEST_GAME)
+                    "settings" -> Settings
+                    else -> Home
+                }
+            }
+        )
+    }
+}
+
 @Composable
 fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
     val state by viewModel.uiState.collectAsState()
-    var showPractice by rememberSaveable { mutableStateOf(false) }
-    var showGames by rememberSaveable { mutableStateOf(false) }
-    var showCoach by rememberSaveable { mutableStateOf(false) }
-    var showSettings by rememberSaveable { mutableStateOf(false) }
-    var showPlaySetup by rememberSaveable { mutableStateOf(false) }
-    // Set when the coach's action opens practice: switch to the lesson
-    // queue on entry instead of the default mixed queue
-    var openLessonOnPractice by rememberSaveable { mutableStateOf(false) }
-    // -1 = no game open; rememberSaveable needs a non-null primitive
-    var reviewGameId by rememberSaveable { mutableStateOf(-1L) }
-
-    if (reviewGameId >= 0) {
-        val reviewViewModel: ReviewViewModel = viewModel()
-        val reviewState by reviewViewModel.uiState.collectAsState()
-        // Reload on every entry and id change: the Activity-scoped
-        // ViewModel would otherwise keep showing a previously loaded game
-        LaunchedEffect(reviewGameId) { reviewViewModel.load(reviewGameId) }
-        ReviewScreen(
-            state = reviewState,
-            onPrevious = reviewViewModel::previous,
-            onNext = reviewViewModel::next,
-            onBack = { reviewGameId = -1L }
-        )
-        return
+    var screen: Screen by rememberSaveable(stateSaver = Screen.Saver) {
+        mutableStateOf(Screen.Home)
     }
+    var showAbandonConfirm by remember { mutableStateOf(false) }
 
-    if (showGames) {
-        val gamesViewModel: GamesViewModel = viewModel()
-        val gamesState by gamesViewModel.uiState.collectAsState()
-        LaunchedEffect(Unit) { gamesViewModel.refresh() }
-        GamesScreen(
-            state = gamesState,
-            onOpenGame = { reviewGameId = it },
-            onBack = { showGames = false }
-        )
-        return
-    }
-
-    if (showPractice) {
-        val practiceViewModel: PracticeViewModel = viewModel()
-        val practiceState by practiceViewModel.uiState.collectAsState()
-        LaunchedEffect(openLessonOnPractice) {
-            if (openLessonOnPractice) {
-                practiceViewModel.setSource(DrillSelector.Source.LESSON)
-                openLessonOnPractice = false
-            }
+    // System back mirrors the on-screen Back everywhere instead of killing
+    // the Activity; mid-game it asks first, since leaving is a resignation
+    BackHandler(enabled = state.phase != GamePhase.SETUP || screen != Screen.Home) {
+        when {
+            state.phase == GamePhase.PLAYING -> showAbandonConfirm = true
+            state.phase == GamePhase.GAME_OVER -> viewModel.backToSetup()
+            screen is Screen.Review -> screen = Screen.Games
+            else -> screen = Screen.Home
         }
-        PracticeScreen(
-            state = practiceState,
-            onSquareTapped = practiceViewModel::onSquareTapped,
-            onSourceChanged = practiceViewModel::setSource,
-            onNext = practiceViewModel::nextDrill,
-            onBack = { showPractice = false }
-        )
-        return
     }
 
-    if (showCoach) {
-        val coachViewModel: CoachViewModel = viewModel()
-        val coachState by coachViewModel.uiState.collectAsState()
-        // Recompute on every entry: games and drills since the last visit
-        // change the advice
-        LaunchedEffect(Unit) { coachViewModel.refresh() }
-        CoachScreen(
-            state = coachState,
-            onAction = { action ->
-                showCoach = false
-                when (action) {
-                    // Same one-tap philosophy as the Play tile: the coach's
-                    // "play a game" starts one, it doesn't open a form
-                    CoachAdvisor.Action.PLAY_GAME -> viewModel.startGame(false)
-                    CoachAdvisor.Action.START_LESSON -> {
-                        openLessonOnPractice = true
-                        showPractice = true
-                    }
-                    CoachAdvisor.Action.REVIEW_GAMES -> showGames = true
-                }
+    // An active game overlays whatever destination is set
+    if (state.phase != GamePhase.SETUP) {
+        GameScreen(
+            state = state,
+            onSquareTapped = viewModel::onSquareTapped,
+            onUndo = viewModel::undoMove,
+            onHint = viewModel::requestHint,
+            onWhyTapped = viewModel::toggleMoveWhy,
+            onResign = viewModel::resign,
+            onNewGame = {
+                screen = Screen.Home
+                viewModel.backToSetup()
             },
-            onBack = { showCoach = false }
+            onPlayAgain = { viewModel.startGame(false) },
+            onReviewGame = {
+                screen = Screen.Review(Screen.LATEST_GAME)
+                viewModel.backToSetup()
+            }
         )
-        return
-    }
-
-    if (showSettings) {
-        SettingsScreen(
-            stats = state.playerStats,
-            animationsEnabled = state.animationsEnabled,
-            onAnimationsChanged = viewModel::setAnimationsEnabled,
-            onBack = { showSettings = false }
-        )
-        return
-    }
-
-    when (state.phase) {
-        GamePhase.SETUP -> if (showPlaySetup) {
-            PlaySetupScreen(
-                stats = state.playerStats,
-                opponentElo = state.opponentElo,
-                playerColor = state.playerColor,
-                gameMode = state.gameMode,
-                onOpponentEloChanged = viewModel::setOpponentElo,
-                onPlayerColorChanged = viewModel::setPlayerColor,
-                onGameModeChanged = viewModel::setGameMode,
-                // Close the setup screen as the game starts: post-game
-                // "New Game" then lands on home, never back on this form
-                onStartGame = { random ->
-                    showPlaySetup = false
-                    viewModel.startGame(random)
+        if (showAbandonConfirm && state.phase == GamePhase.PLAYING) {
+            AlertDialog(
+                onDismissRequest = { showAbandonConfirm = false },
+                title = { Text("Leave the game?") },
+                text = { Text("Leaving counts as a resignation.") },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showAbandonConfirm = false
+                        viewModel.resign()
+                    }) { Text("Resign") }
                 },
-                onBack = { showPlaySetup = false }
+                dismissButton = {
+                    TextButton(onClick = { showAbandonConfirm = false }) {
+                        Text("Keep playing")
+                    }
+                }
             )
-        } else {
+        }
+        return
+    }
+
+    when (val current = screen) {
+        Screen.Home -> {
             val coachViewModel: CoachViewModel = viewModel()
             val coachState by coachViewModel.uiState.collectAsState()
             // Keep the Coach tile's one-liner current with the latest games
@@ -186,22 +199,109 @@ fun RaiChessApp(viewModel: GameViewModel = viewModel()) {
                 // Straight into the game with the current setup; the tile's
                 // corner button is the path to the setup screen
                 onPlay = { viewModel.startGame(false) },
-                onCustomizeGame = { showPlaySetup = true },
-                onTrain = { showPractice = true },
-                onCoach = { showCoach = true },
-                onReview = { showGames = true },
-                onSettings = { showSettings = true }
+                onCustomizeGame = { screen = Screen.PlaySetup },
+                onTrain = { screen = Screen.Practice() },
+                onCoach = { screen = Screen.Coach },
+                onReview = { screen = Screen.Games },
+                onSettings = { screen = Screen.Settings }
             )
         }
 
-        GamePhase.PLAYING, GamePhase.GAME_OVER -> GameScreen(
-            state = state,
-            onSquareTapped = viewModel::onSquareTapped,
-            onUndo = viewModel::undoMove,
-            onHint = viewModel::requestHint,
-            onWhyTapped = viewModel::toggleMoveWhy,
-            onResign = viewModel::resign,
-            onNewGame = viewModel::backToSetup
+        Screen.PlaySetup -> PlaySetupScreen(
+            stats = state.playerStats,
+            opponentElo = state.opponentElo,
+            playerColor = state.playerColor,
+            gameMode = state.gameMode,
+            onOpponentEloChanged = viewModel::setOpponentElo,
+            onPlayerColorChanged = viewModel::setPlayerColor,
+            onGameModeChanged = viewModel::setGameMode,
+            // Land on home when the game ends, not back on this form
+            onStartGame = { random ->
+                screen = Screen.Home
+                viewModel.startGame(random)
+            },
+            onBack = { screen = Screen.Home }
+        )
+
+        is Screen.Practice -> {
+            val practiceViewModel: PracticeViewModel = viewModel()
+            val practiceState by practiceViewModel.uiState.collectAsState()
+            // Coach deep-link: open on the lesson queue instead of Mixed.
+            // Keyed on the screen value; setSource self-guards re-fires.
+            LaunchedEffect(current) {
+                if (current.openLesson) {
+                    practiceViewModel.setSource(DrillSelector.Source.LESSON)
+                }
+            }
+            PracticeScreen(
+                state = practiceState,
+                onSquareTapped = practiceViewModel::onSquareTapped,
+                onSourceChanged = practiceViewModel::setSource,
+                onNext = practiceViewModel::nextDrill,
+                onBack = { screen = Screen.Home }
+            )
+        }
+
+        Screen.Coach -> {
+            val coachViewModel: CoachViewModel = viewModel()
+            val coachState by coachViewModel.uiState.collectAsState()
+            // Recompute on every entry: games and drills since the last
+            // visit change the advice
+            LaunchedEffect(Unit) { coachViewModel.refresh() }
+            CoachScreen(
+                state = coachState,
+                onAction = { action ->
+                    when (action) {
+                        // Same one-tap philosophy as the Play tile: the
+                        // coach's "play a game" starts one, not a form
+                        CoachAdvisor.Action.PLAY_GAME -> {
+                            screen = Screen.Home
+                            viewModel.startGame(false)
+                        }
+                        CoachAdvisor.Action.START_LESSON ->
+                            screen = Screen.Practice(openLesson = true)
+                        CoachAdvisor.Action.REVIEW_GAMES ->
+                            screen = Screen.Review(Screen.LATEST_GAME)
+                    }
+                },
+                onBack = { screen = Screen.Home }
+            )
+        }
+
+        Screen.Games -> {
+            val gamesViewModel: GamesViewModel = viewModel()
+            val gamesState by gamesViewModel.uiState.collectAsState()
+            LaunchedEffect(Unit) { gamesViewModel.refresh() }
+            GamesScreen(
+                state = gamesState,
+                onOpenGame = { screen = Screen.Review(it) },
+                onBack = { screen = Screen.Home }
+            )
+        }
+
+        is Screen.Review -> {
+            val reviewViewModel: ReviewViewModel = viewModel()
+            val reviewState by reviewViewModel.uiState.collectAsState()
+            // Reload on every entry and id change: the Activity-scoped
+            // ViewModel would otherwise keep showing a previously loaded
+            // game. LATEST_GAME loads the newest game, polling while its
+            // analysis lands.
+            LaunchedEffect(current) {
+                reviewViewModel.load(current.gameId.takeIf { it >= 0 })
+            }
+            ReviewScreen(
+                state = reviewState,
+                onPrevious = reviewViewModel::previous,
+                onNext = reviewViewModel::next,
+                onBack = { screen = Screen.Games }
+            )
+        }
+
+        Screen.Settings -> SettingsScreen(
+            stats = state.playerStats,
+            animationsEnabled = state.animationsEnabled,
+            onAnimationsChanged = viewModel::setAnimationsEnabled,
+            onBack = { screen = Screen.Home }
         )
     }
 }

--- a/app/src/main/java/com/raichess/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/SettingsRepository.kt
@@ -21,11 +21,16 @@ class SettingsRepository(context: Context) {
             prefs.edit().putBoolean(KEY_ANIMATIONS, value).apply()
         }
 
-    /** Remembers the player's last-selected game mode across launches. */
+    /**
+     * Remembers the player's last-selected game mode across launches.
+     * First-run default is TRAINING: with instant-play from the home tile,
+     * a brand-new player's first game should land in the assisted,
+     * coach-visible mode — Rated is an explicit choice, not a surprise.
+     */
     var gameMode: GameMode
         get() = when (prefs.getString(KEY_GAME_MODE, null)) {
-            GameMode.TRAINING.name -> GameMode.TRAINING
-            else -> GameMode.RATED
+            GameMode.RATED.name -> GameMode.RATED
+            else -> GameMode.TRAINING
         }
         set(value) {
             prefs.edit().putString(KEY_GAME_MODE, value.name).apply()

--- a/app/src/main/java/com/raichess/domain/usecase/CoachAdvisor.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/CoachAdvisor.kt
@@ -2,6 +2,7 @@ package com.raichess.domain.usecase
 
 import com.raichess.domain.model.EloCalculator
 import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.GameResult
 import com.raichess.domain.model.ThemeTag
 import kotlin.math.roundToInt
 
@@ -19,11 +20,7 @@ import kotlin.math.roundToInt
  */
 object CoachAdvisor {
 
-    /**
-     * What the coach suggests doing next. REVIEW_GAMES is wired in the UI
-     * but not yet produced by [advise] — reserved for a future
-     * "review that loss" recommendation.
-     */
+    /** What the coach suggests doing next. */
     enum class Action { PLAY_GAME, START_LESSON, REVIEW_GAMES }
 
     data class Advice(
@@ -41,7 +38,9 @@ object CoachAdvisor {
         stats: EloStats?,
         profile: WeaknessProfile,
         plan: List<LessonPlanner.Lesson>,
-        solves: Map<String, Int>
+        solves: Map<String, Int>,
+        /** True when the player's most recent finished game was a loss. */
+        lastGameWasLoss: Boolean = false
     ): Advice {
         val gamesPlayed = stats?.gamesPlayed ?: 0
         if (gamesPlayed == 0) return welcome(plan)
@@ -88,11 +87,45 @@ object CoachAdvisor {
             }
         }
 
-        return if (lesson != null) {
-            Advice(headline, detail, focuses, Action.START_LESSON, "Continue: ${lesson.title}")
-        } else {
-            Advice(headline, detail, focuses, Action.PLAY_GAME, "Play a game")
+        // A fresh loss outranks the standing plan: reviewing it while it's
+        // recent is the most coach-like move available, and the lesson is
+        // still listed as a focus above
+        return when {
+            lastGameWasLoss -> Advice(
+                headline, detail,
+                focuses + "That last loss is worth a look together — losses teach fastest.",
+                Action.REVIEW_GAMES, "Review your last game"
+            )
+            lesson != null ->
+                Advice(headline, detail, focuses, Action.START_LESSON, "Continue: ${lesson.title}")
+            else ->
+                Advice(headline, detail, focuses, Action.PLAY_GAME, "Play a game")
         }
+    }
+
+    /**
+     * One-line reaction to a just-finished game, shown on the game-over
+     * screen. Same tone rules as [advise]; picks the most noteworthy thing
+     * about the result.
+     */
+    fun react(
+        result: GameResult,
+        newPeak: Boolean,
+        winStreak: Int,
+        calibrating: Boolean
+    ): String = when {
+        result == GameResult.WIN && newPeak ->
+            "New peak — that's real progress. Noted."
+        result == GameResult.WIN && winStreak >= 3 ->
+            "That's $winStreak in a row — you're trending up."
+        result == GameResult.WIN ->
+            "Well played. Ready for the next one when you are."
+        result == GameResult.DRAW ->
+            "A solid hold. Let's find the half-point you left behind."
+        calibrating ->
+            "Good data — I'm still finding your level, and this helps."
+        else ->
+            "Every loss is practice material — let's see what this one teaches."
     }
 
     /** First-run voice: no games yet, nothing to diagnose. */

--- a/app/src/main/java/com/raichess/ui/coach/CoachScreen.kt
+++ b/app/src/main/java/com/raichess/ui/coach/CoachScreen.kt
@@ -5,17 +5,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.raichess.domain.usecase.CoachAdvisor
 import com.raichess.ui.components.RaiLogo
+import com.raichess.ui.components.RaiScreen
 import com.raichess.ui.components.SectionLabel
 import com.raichess.ui.theme.ChessColors
 
@@ -40,25 +37,21 @@ fun CoachScreen(
     onAction: (CoachAdvisor.Action) -> Unit,
     onBack: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 28.dp, vertical = 40.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            RaiLogo(size = 36.dp)
-            Spacer(modifier = Modifier.width(10.dp))
-            Text(
-                text = "Coach",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onBackground
-            )
+    RaiScreen(
+        title = "Coach",
+        onBack = onBack,
+        titleRow = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                RaiLogo(size = 36.dp)
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = "Coach",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
         }
-
-        Spacer(modifier = Modifier.height(28.dp))
-
+    ) {
         if (state.loading) {
             Text(
                 "Thinking…",
@@ -135,14 +128,6 @@ fun CoachScreen(
                     }
                 }
             }
-        }
-
-        Spacer(modifier = Modifier.height(28.dp))
-        OutlinedButton(
-            onClick = onBack,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Back")
         }
     }
 }

--- a/app/src/main/java/com/raichess/ui/coach/CoachViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/coach/CoachViewModel.kt
@@ -7,9 +7,12 @@ import androidx.lifecycle.viewModelScope
 import com.raichess.data.repository.GameRepository
 import com.raichess.data.repository.LessonRepository
 import com.raichess.data.repository.PlayerProfileRepository
+import com.raichess.domain.model.GameResult
+import com.raichess.domain.model.PlayerColor
 import com.raichess.domain.usecase.CoachAdvisor
 import com.raichess.domain.usecase.LessonPlanner
 import com.raichess.domain.usecase.WeaknessProfile
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -50,12 +53,16 @@ class CoachViewModel(application: Application) : AndroidViewModel(application) {
     private val _uiState = MutableStateFlow(CoachUiState())
     val uiState: StateFlow<CoachUiState> = _uiState
 
-    init {
-        refresh()
-    }
+    // No refresh() in init: every screen that shows coach state refreshes
+    // on entry (MainActivity LaunchedEffect), and the first entry is the
+    // home screen itself — an init call would just compute everything twice
+    private var refreshJob: Job? = null
 
     fun refresh() {
-        viewModelScope.launch {
+        // A newer refresh owns the state; racing loads would finish
+        // last-write-wins otherwise
+        refreshJob?.cancel()
+        refreshJob = viewModelScope.launch {
             val profile = try {
                 gameRepository.weaknessProfile()
             } catch (e: Exception) {
@@ -70,7 +77,17 @@ class CoachViewModel(application: Application) : AndroidViewModel(application) {
                 Log.w(TAG, "lesson progress unavailable", e)
                 emptyMap()
             }
-            val advice = CoachAdvisor.advise(stats, profile, plan, solves)
+            val lastGameWasLoss = try {
+                gameRepository.recentGames(1).firstOrNull()?.let { game ->
+                    val color = runCatching { PlayerColor.valueOf(game.playerColor) }
+                        .getOrDefault(PlayerColor.WHITE)
+                    GameResult.fromPgnResult(game.result, color) == GameResult.LOSS
+                } ?: false
+            } catch (e: Exception) {
+                Log.w(TAG, "last game unavailable", e)
+                false
+            }
+            val advice = CoachAdvisor.advise(stats, profile, plan, solves, lastGameWasLoss)
             val active = LessonPlanner.activeLesson(plan, solves)
 
             _uiState.value = CoachUiState(

--- a/app/src/main/java/com/raichess/ui/components/Controls.kt
+++ b/app/src/main/java/com/raichess/ui/components/Controls.kt
@@ -5,15 +5,21 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -24,6 +30,54 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.raichess.ui.theme.ChessColors
+
+/**
+ * Shared scaffold for the setup-style screens (play setup, coach,
+ * settings, games): consistent padding, a title (or custom [titleRow]),
+ * the content, and the bottom Back button — one place instead of five
+ * hand-rolled copies. Window insets are handled globally in MainActivity.
+ *
+ * [scrollable] = false is for screens whose content manages its own
+ * scrolling (e.g. a weighted list); their content can use ColumnScope
+ * weights, which a scrolling column can't offer.
+ */
+@Composable
+internal fun RaiScreen(
+    title: String,
+    onBack: () -> Unit,
+    scrollable: Boolean = true,
+    titleRow: (@Composable () -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .then(
+                if (scrollable) Modifier.verticalScroll(rememberScrollState()) else Modifier
+            )
+            .padding(horizontal = 28.dp, vertical = 40.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        if (titleRow != null) {
+            titleRow()
+        } else {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        content()
+        Spacer(modifier = Modifier.height(24.dp))
+        OutlinedButton(
+            onClick = onBack,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Back")
+        }
+    }
+}
 
 /**
  * Shared form controls for the setup-style screens (home, play setup,

--- a/app/src/main/java/com/raichess/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameScreen.kt
@@ -18,15 +18,19 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -64,7 +68,9 @@ fun GameScreen(
     onHint: () -> Unit,
     onWhyTapped: () -> Unit,
     onResign: () -> Unit,
-    onNewGame: () -> Unit
+    onNewGame: () -> Unit,
+    onPlayAgain: () -> Unit = onNewGame,
+    onReviewGame: (() -> Unit)? = null
 ) {
     val flipped = state.playerColor == PlayerColor.BLACK
     val material = remember(state.squares) { MaterialCalculator.compute(state.squares) }
@@ -107,8 +113,19 @@ fun GameScreen(
             text = statusText(state, thinkingTick),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.secondary,
+            textAlign = TextAlign.Center,
             modifier = Modifier.padding(vertical = 6.dp)
         )
+        // The coach gets a word in at game over (Training only)
+        if (state.phase == GamePhase.GAME_OVER && state.coachReaction != null) {
+            Text(
+                text = "Rai: ${state.coachReaction}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+        }
 
         // Coach line (Training only — Rated shouldn't pay a blank gap for a
         // feature it never shows): a requested hint, else the live move
@@ -121,7 +138,10 @@ fun GameScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(coachLineHeight)
+                    // min, not fixed: at large accessibility font scales the
+                    // two lines outgrow the 1.0x-derived slot — growing the
+                    // slot (one-time reflow) beats clipping the text
+                    .heightIn(min = coachLineHeight)
                     .then(
                         if (whyTappable) Modifier.clickable(onClick = onWhyTapped)
                         else Modifier
@@ -168,11 +188,13 @@ fun GameScreen(
                 .weight(1f)
         )
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly
-        ) {
-            if (state.phase == GamePhase.PLAYING) {
+        if (state.phase == GamePhase.PLAYING) {
+            // Resign is one mis-tap from a recorded loss — confirm it
+            var showResignConfirm by remember { mutableStateOf(false) }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
                 if (state.gameMode == GameMode.TRAINING) {
                     OutlinedButton(onClick = onUndo, enabled = state.canUndo) {
                         Text(if (state.undoCount > 0) "Undo (${state.undoCount})" else "Undo")
@@ -187,12 +209,50 @@ fun GameScreen(
                         Text(if (state.hintCount > 0) "Hint (${state.hintCount})" else "Hint")
                     }
                 }
-                OutlinedButton(onClick = onResign) {
+                OutlinedButton(onClick = { showResignConfirm = true }) {
                     Text("Resign")
                 }
-            } else {
+            }
+            if (showResignConfirm) {
+                AlertDialog(
+                    onDismissRequest = { showResignConfirm = false },
+                    title = { Text("Resign?") },
+                    text = { Text("This counts as a loss.") },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            showResignConfirm = false
+                            onResign()
+                        }) { Text("Resign") }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showResignConfirm = false }) {
+                            Text("Keep playing")
+                        }
+                    }
+                )
+            }
+        } else {
+            // Game-over panel: review-while-motivated first, then rematch
+            // or home. No review for a game with no stored moves (instant
+            // resign) — there'd be nothing to open.
+            if (onReviewGame != null && state.moveHistorySan.isNotEmpty()) {
+                Button(
+                    onClick = onReviewGame,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Review this game")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                OutlinedButton(onClick = onPlayAgain) {
+                    Text("Play again")
+                }
                 OutlinedButton(onClick = onNewGame) {
-                    Text("New Game")
+                    Text("Home")
                 }
             }
         }
@@ -578,7 +638,16 @@ private fun statusText(state: GameUiState, thinkingTick: Int = 0): String {
 private fun eloDeltaText(state: GameUiState): String {
     val delta = state.eloDelta ?: return ""
     val sign = if (delta >= 0) "+" else ""
-    return " ELO $sign$delta → ${state.playerStats?.currentElo ?: ""}"
+    val base = " ELO $sign$delta → ${state.playerStats?.currentElo ?: ""}"
+    // Itemize the assistance cost so a shrunken gain is explained, not a
+    // mystery — and so players can see hints are cheap, not punitive
+    val clean = state.eloDeltaClean ?: return base
+    val cleanSign = if (clean >= 0) "+" else ""
+    val assists = listOfNotNull(
+        state.hintCount.takeIf { it > 0 }?.let { "$it hint${if (it == 1) "" else "s"}" },
+        state.undoCount.takeIf { it > 0 }?.let { "$it undo${if (it == 1) "" else "s"}" }
+    ).joinToString(", ")
+    return "$base ($cleanSign$clean without $assists)"
 }
 
 /** Celebrate a rating personal best the moment it happens. */

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -35,6 +35,7 @@ import com.raichess.domain.model.ThemeTag
 import com.raichess.domain.model.UndoPenalty
 import com.raichess.domain.model.WinProbability
 import com.raichess.domain.model.canUndo
+import com.raichess.domain.usecase.CoachAdvisor
 import com.raichess.domain.usecase.HintAdvisor
 import com.raichess.domain.usecase.ThemeTagger
 import kotlinx.coroutines.Dispatchers
@@ -107,8 +108,16 @@ data class GameUiState(
     val isPlayerInCheck: Boolean = false,
     val ending: GameEnding? = null,
     val eloDelta: Int? = null,
+    /**
+     * What [eloDelta] would have been with zero hints/undos, or null when
+     * no assists were used. Shown at game over so the cost of assistance
+     * is visible, not a mystery.
+     */
+    val eloDeltaClean: Int? = null,
     /** True when this game's result set a strictly new peak ELO. */
-    val isNewPeak: Boolean = false
+    val isNewPeak: Boolean = false,
+    /** The coach's one-line reaction to the finished game (Training only). */
+    val coachReaction: String? = null
 )
 
 class GameViewModel(application: Application) : AndroidViewModel(application) {
@@ -245,7 +254,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             isPlayerInCheck = false,
             ending = null,
             eloDelta = null,
+            eloDeltaClean = null,
             isNewPeak = false,
+            coachReaction = null,
             undoCount = 0,
             canUndo = false,
             moveSeq = 0,
@@ -786,6 +797,22 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         // folded this game into peakElo, so equality afterwards can't tell
         // a fresh high from re-climbing to a previous one
         val previousPeak = state.playerStats?.peakElo
+        // Counterfactual for the game-over line: what the delta would have
+        // been with zero assists (neutral accuracy, no gain gating), so the
+        // player can see exactly what the hints/undos cost
+        val preStats = state.playerStats
+        val cleanDelta = if (assistedMoves > 0 && preStats != null) {
+            EloCalculator.calculateNewElo(
+                currentElo = preStats.currentElo,
+                opponentElo = state.opponentElo,
+                result = result,
+                moveAccuracy = UndoPenalty.NEUTRAL_ACCURACY,
+                gamesPlayed = preStats.gamesPlayed,
+                assistedMoves = 0
+            ) - preStats.currentElo
+        } else {
+            null
+        }
         val (stats, delta) = repository.recordResult(result, state.opponentElo, accuracy, assistedMoves)
         persistFinishedGame(state, result, eloAfter = stats.currentElo, eloDelta = delta)
         // Calibration: while the rating is provisional (and moving fast,
@@ -797,6 +824,7 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         } else {
             state.opponentElo
         }
+        val isNewPeak = previousPeak != null && stats.peakElo > previousPeak
         _uiState.value = state.copy(
             phase = GamePhase.GAME_OVER,
             playerStats = stats,
@@ -805,7 +833,19 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             isPlayerTurn = false,
             ending = ending,
             eloDelta = delta,
-            isNewPeak = previousPeak != null && stats.peakElo > previousPeak,
+            eloDeltaClean = cleanDelta?.takeIf { it != delta },
+            isNewPeak = isNewPeak,
+            // The coach speaks at game over in Training; Rated stays terse
+            coachReaction = if (state.gameMode == GameMode.TRAINING) {
+                CoachAdvisor.react(
+                    result = result,
+                    newPeak = isNewPeak,
+                    winStreak = stats.winStreak,
+                    calibrating = stats.gamesPlayed < EloCalculator.PROVISIONAL_GAMES
+                )
+            } else {
+                null
+            },
             canUndo = false,
             canHint = false,
             coachWarning = false,

--- a/app/src/main/java/com/raichess/ui/games/GamesScreen.kt
+++ b/app/src/main/java/com/raichess/ui/games/GamesScreen.kt
@@ -5,20 +5,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.raichess.ui.components.RaiScreen
 
 /**
  * Browsable game history: every stored game, newest first; tapping a row
@@ -30,19 +27,7 @@ fun GamesScreen(
     onOpenGame: (Long) -> Unit,
     onBack: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = "Games",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onBackground
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-
+    RaiScreen(title = "Games", onBack = onBack, scrollable = false) {
         when {
             state.loading -> Text(
                 "Loading…",
@@ -93,7 +78,5 @@ fun GamesScreen(
         }
 
         if (state.loading || state.rows.isEmpty()) Spacer(modifier = Modifier.weight(1f))
-
-        OutlinedButton(onClick = onBack) { Text("Back") }
     }
 }

--- a/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/raichess/ui/home/HomeScreen.kt
@@ -3,14 +3,18 @@ package com.raichess.ui.home
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -110,9 +114,13 @@ fun HomeScreen(
 
         Spacer(modifier = Modifier.height(28.dp))
 
-        // Destination quad
+        // Destination quad. IntrinsicSize.Min rows: both tiles in a row
+        // share the taller tile's height, and tiles grow with font scale
+        // instead of clipping (see HomeTile's min height).
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             HomeTile(
@@ -135,7 +143,9 @@ fun HomeScreen(
         }
         Spacer(modifier = Modifier.height(12.dp))
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             HomeTile(
@@ -145,10 +155,12 @@ fun HomeScreen(
                 onClick = onCoach,
                 modifier = Modifier.weight(1f)
             )
+            // "Games", not "Review": the tile opens the history screen
+            // titled Games — one name per concept
             HomeTile(
                 glyph = "♜",
-                title = "Review",
-                subtitle = "Browse past games",
+                title = "Games",
+                subtitle = "History & review",
                 onClick = onReview,
                 modifier = Modifier.weight(1f)
             )
@@ -188,10 +200,13 @@ private fun HomeTile(
     val shape = RoundedCornerShape(16.dp)
     Column(
         modifier = modifier
-            .aspectRatio(1f)
+            // Near-square at normal font scale, grows with content at
+            // large accessibility scales instead of clipping
+            .heightIn(min = 132.dp)
+            .fillMaxHeight()
             .clip(shape)
             .border(1.dp, ChessColors.SquareBorder.copy(alpha = 0.35f), shape)
-            .clickable(onClick = onClick)
+            .clickable(onClickLabel = title, onClick = onClick)
             .padding(14.dp),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
@@ -206,16 +221,25 @@ private fun HomeTile(
                 color = MaterialTheme.colorScheme.secondary
             )
             if (cornerLabel != null && onCornerClick != null) {
-                Text(
-                    text = cornerLabel,
-                    style = MaterialTheme.typography.labelSmall,
-                    letterSpacing = 1.sp,
-                    color = MaterialTheme.colorScheme.secondary,
+                // 48dp minimum target: this sits inside a tile whose own
+                // tap instantly starts a game — a near-miss must not
+                Box(
                     modifier = Modifier
+                        .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
                         .clip(RoundedCornerShape(8.dp))
-                        .clickable(onClick = onCornerClick)
-                        .padding(horizontal = 6.dp, vertical = 4.dp)
-                )
+                        .clickable(
+                            onClickLabel = "Customize game",
+                            onClick = onCornerClick
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = cornerLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        letterSpacing = 1.sp,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+                }
             }
         }
         Column {

--- a/app/src/main/java/com/raichess/ui/home/PlaySetupScreen.kt
+++ b/app/src/main/java/com/raichess/ui/home/PlaySetupScreen.kt
@@ -1,15 +1,11 @@
 package com.raichess.ui.home
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -17,7 +13,6 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -27,6 +22,7 @@ import com.raichess.domain.model.EloCalculator
 import com.raichess.domain.model.EloStats
 import com.raichess.domain.model.GameMode
 import com.raichess.domain.model.PlayerColor
+import com.raichess.ui.components.RaiScreen
 import com.raichess.ui.components.Section
 import com.raichess.ui.components.SegmentedControl
 import com.raichess.ui.components.TickLabel
@@ -50,28 +46,15 @@ fun PlaySetupScreen(
     onStartGame: (randomColor: Boolean) -> Unit,
     onBack: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 28.dp, vertical = 40.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = "Play",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onBackground
-        )
+    RaiScreen(title = "Play", onBack = onBack) {
         if (stats != null) {
             Text(
                 text = "You: ${stats.currentElo}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.secondary,
-                modifier = Modifier.padding(top = 4.dp)
+                modifier = Modifier.padding(bottom = 24.dp)
             )
         }
-
-        Spacer(modifier = Modifier.height(28.dp))
 
         // Mode
         Section(label = "Mode") {
@@ -165,13 +148,6 @@ fun PlaySetupScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Random Color")
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        OutlinedButton(
-            onClick = onBack,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Back")
         }
     }
 }

--- a/app/src/main/java/com/raichess/ui/practice/PracticeScreen.kt
+++ b/app/src/main/java/com/raichess/ui/practice/PracticeScreen.kt
@@ -1,5 +1,6 @@
 package com.raichess.ui.practice
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
@@ -9,7 +10,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -21,6 +24,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.raichess.domain.usecase.DrillSelector
 import com.raichess.ui.game.ChessBoard
+import com.raichess.ui.theme.ChessColors
 
 /**
  * Practice screen (Phase D): drills from the player's own analyzed
@@ -115,9 +119,40 @@ fun PracticeScreen(
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.secondary
                 )
-                // Fixed-height prompt slot: no board reflow on feedback
+                // A completed lesson is the biggest earned milestone here —
+                // it gets a distinct celebration card, not a routine prompt
+                val celebrated = state.lessonJustCompletedTitle
+                if (celebrated != null) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                1.dp,
+                                ChessColors.ControlActive,
+                                RoundedCornerShape(12.dp)
+                            )
+                            .padding(horizontal = 14.dp, vertical = 10.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "Lesson complete!",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = ChessColors.ControlActive
+                        )
+                        Text(
+                            text = "$celebrated — done. Rai: one thing trained, on to the next.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(6.dp))
+                }
+                // Min-height prompt slot: no board reflow on feedback at
+                // normal font scale; grows instead of clipping at large ones
                 Box(
-                    modifier = Modifier.fillMaxWidth().height(40.dp),
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 40.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(

--- a/app/src/main/java/com/raichess/ui/practice/PracticeViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/practice/PracticeViewModel.kt
@@ -62,7 +62,13 @@ data class PracticeUiState(
     /** "3 of 8 solved" for the active lesson. */
     val lessonProgressText: String? = null,
     /** True when every lesson in the current plan is complete. */
-    val lessonComplete: Boolean = false
+    val lessonComplete: Boolean = false,
+    /**
+     * Title of the lesson unit the player just finished, or null. Drives
+     * the celebration card — completing a lesson is the biggest earned
+     * milestone in practice and shouldn't render like a routine solve.
+     */
+    val lessonJustCompletedTitle: String? = null
 )
 
 /**
@@ -154,6 +160,7 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
                         lessonComplete = true,
                         lessonTitle = null,
                         lessonProgressText = null,
+                        lessonJustCompletedTitle = null,
                         practiceRating = targetRating
                     )
                     return@launch
@@ -176,6 +183,7 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
                     lessonTitle = lesson.title,
                     lessonProgressText =
                         "${(solves[lesson.id] ?: 0)} of ${lesson.targetSolves} solved",
+                    lessonJustCompletedTitle = null,
                     practiceRating = targetRating
                 )
                 if (queue.isNotEmpty()) startDrill(queue[0])
@@ -204,6 +212,7 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
                 lessonComplete = false,
                 lessonTitle = null,
                 lessonProgressText = null,
+                lessonJustCompletedTitle = null,
                 practiceRating = targetRating
             )
             if (queue.isNotEmpty()) startDrill(queue[0])
@@ -393,7 +402,7 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
         // Lesson bookkeeping: solves advance the active unit; completing
         // it flags the next "Next" tap to load the following lesson
         var lessonProgress: String? = null
-        var lessonDonePrompt: String? = null
+        var lessonDoneTitle: String? = null
         val lesson = activeLessonUnit
         if (solved && state.source == DrillSelector.Source.LESSON && lesson != null) {
             val solves = try {
@@ -407,7 +416,7 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
                     "${solves.coerceAtMost(lesson.targetSolves)} of ${lesson.targetSolves} solved"
                 if (solves >= lesson.targetSolves) {
                     lessonJustCompleted = true
-                    lessonDonePrompt = "Lesson complete! Tap Next for your next lesson."
+                    lessonDoneTitle = lesson.title
                 }
             }
         }
@@ -416,10 +425,11 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
             squares = boardSnapshot(),
             phase = if (solved) DrillPhase.SOLVED else DrillPhase.FAILED,
             prompt = when {
-                lessonDonePrompt != null -> lessonDonePrompt
+                lessonDoneTitle != null -> "Tap Next for your next lesson."
                 solved -> if (streak >= 3) "Solved! $streak in a row!" else "Solved!"
                 else -> failPrompt(revealLan)
             },
+            lessonJustCompletedTitle = lessonDoneTitle,
             lessonProgressText = lessonProgress ?: state.lessonProgressText,
             selectedSquare = null,
             legalTargets = emptySet(),

--- a/app/src/main/java/com/raichess/ui/review/ReviewScreen.kt
+++ b/app/src/main/java/com/raichess/ui/review/ReviewScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -64,7 +65,7 @@ fun ReviewScreen(
                 "Play a game and it'll be analyzed for review here."
             )
             state.analysisPending -> ReviewMessage(
-                "Your last game is still being analyzed — check back in a moment."
+                "Analyzing your game — this page updates when it's ready."
             )
             state.cleanGame -> {
                 Headline(state.headline)
@@ -81,9 +82,10 @@ fun ReviewScreen(
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onBackground
                 )
-                // Fixed-height detail slot: no board reflow while stepping
+                // Min-height detail slot: no board reflow while stepping at
+                // normal font scale; grows instead of clipping at large ones
                 Box(
-                    modifier = Modifier.fillMaxWidth().height(64.dp),
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 64.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(

--- a/app/src/main/java/com/raichess/ui/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/review/ReviewViewModel.kt
@@ -15,6 +15,7 @@ import com.raichess.domain.model.ThemeTag
 import com.raichess.domain.usecase.HintAdvisor
 import com.raichess.ui.game.LastMove
 import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -65,31 +66,64 @@ class ReviewViewModel(application: Application) : AndroidViewModel(application) 
     private val _uiState = MutableStateFlow(ReviewUiState())
     val uiState: StateFlow<ReviewUiState> = _uiState
 
+    /** Bumped by every load(); in-flight polls from older loads bail out. */
+    private var loadSeq = 0
+
     init {
         load()
     }
 
+    /** Explicit id → that game; null → the most recent game, any state. */
+    private suspend fun fetch(gameId: Long?) = if (gameId != null) {
+        gameRepository.getGame(gameId)
+    } else {
+        gameRepository.recentGames(1).firstOrNull()
+    }
+
     /**
-     * Load a specific game's review, or the most recent analyzed game when
-     * [gameId] is null. Public and re-callable: the screen reloads on every
-     * entry (the Activity-scoped ViewModel used to load once in init and
-     * then showed a stale game forever after new games were played).
+     * Load a specific game's review, or the most recent game when [gameId]
+     * is null (the game-over "Review this game" path — that game may still
+     * be saving or analyzing, so pending states poll until the analysis
+     * lands instead of demanding a manual back-and-retry). Public and
+     * re-callable: the screen reloads on every entry (the Activity-scoped
+     * ViewModel used to load once in init and then showed a stale game
+     * forever after new games were played).
      */
     fun load(gameId: Long? = null) {
         _uiState.value = ReviewUiState()
+        val seq = ++loadSeq
         viewModelScope.launch {
             try {
-                val game = if (gameId != null) {
-                    gameRepository.getGame(gameId)
-                } else {
-                    gameRepository.recentGames(20)
-                        .firstOrNull { it.analysisState == AnalysisState.DONE }
-                }
-                if (game == null || game.analysisState != AnalysisState.DONE) {
+                var game = fetch(gameId)
+                if (game == null || game.analysisState == AnalysisState.PENDING) {
                     // Nudge the background analyzer: if this game's analysis
                     // was interrupted (app killed mid-sweep), this is what
                     // finishes it so the next visit has the full review
                     AnalysisCoordinator.analyzePendingGames(getApplication())
+                    val anyGames = game != null || gameRepository.recentGames(1).isNotEmpty()
+                    _uiState.value = ReviewUiState(
+                        loading = false,
+                        // In latest-game mode the row may simply not be
+                        // saved yet — treat "no games" as pending too and
+                        // let the poll below find it
+                        noGames = gameId != null && !anyGames,
+                        analysisPending = gameId == null || anyGames
+                    )
+                    // Analysis takes ~15s of engine time; poll rather than
+                    // sending the player away to come back manually
+                    var attempts = 0
+                    while (attempts < MAX_PENDING_POLLS &&
+                        (game == null || game.analysisState == AnalysisState.PENDING)
+                    ) {
+                        delay(PENDING_POLL_MS)
+                        // A newer load() owns the screen now — stop quietly
+                        if (seq != loadSeq) return@launch
+                        game = fetch(gameId)
+                        attempts++
+                    }
+                    if (seq != loadSeq) return@launch
+                }
+                if (game == null || game.analysisState != AnalysisState.DONE) {
                     val anyGames = game != null || gameRepository.recentGames(1).isNotEmpty()
                     _uiState.value = ReviewUiState(
                         loading = false,
@@ -171,5 +205,9 @@ class ReviewViewModel(application: Application) : AndroidViewModel(application) 
          * worth replaying, not every half-pawn slip.
          */
         private val GRADED = setOf("MISTAKE", "BLUNDER")
+
+        // ~15s of engine time per analysis; 12 × 2.5s comfortably covers it
+        private const val MAX_PENDING_POLLS = 12
+        private const val PENDING_POLL_MS = 2500L
     }
 }

--- a/app/src/main/java/com/raichess/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/raichess/ui/settings/SettingsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -14,7 +13,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -34,6 +32,7 @@ import androidx.compose.ui.unit.sp
 import com.raichess.BuildConfig
 import com.raichess.data.diagnostics.EngineDiagnostics
 import com.raichess.domain.model.EloStats
+import com.raichess.ui.components.RaiScreen
 import com.raichess.ui.components.RecordRow
 import com.raichess.ui.components.Section
 import com.raichess.ui.components.SectionLabel
@@ -51,21 +50,7 @@ fun SettingsScreen(
     onAnimationsChanged: (Boolean) -> Unit,
     onBack: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 28.dp, vertical = 40.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = "Settings",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onBackground
-        )
-
-        Spacer(modifier = Modifier.height(28.dp))
-
+    RaiScreen(title = "Settings", onBack = onBack) {
         if (stats != null) {
             Section(label = "Record") {
                 RecordRow(
@@ -127,14 +112,6 @@ fun SettingsScreen(
             letterSpacing = 1.sp,
             color = MaterialTheme.colorScheme.secondary
         )
-
-        Spacer(modifier = Modifier.height(28.dp))
-        OutlinedButton(
-            onClick = onBack,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Back")
-        }
     }
 }
 

--- a/app/src/test/java/com/raichess/domain/usecase/CoachAdvisorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/CoachAdvisorTest.kt
@@ -1,6 +1,7 @@
 package com.raichess.domain.usecase
 
 import com.raichess.domain.model.EloStats
+import com.raichess.domain.model.GameResult
 import com.raichess.domain.model.ThemeTag
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -84,6 +85,42 @@ class CoachAdvisorTest {
     fun `clean profile stays encouraging`() {
         val advice = CoachAdvisor.advise(stats(25), WeaknessProfile.EMPTY, defaultPlan, emptyMap())
         assertEquals("Looking sharp.", advice.headline)
+    }
+
+    @Test
+    fun `a fresh loss makes the coach suggest reviewing it`() {
+        val advice = CoachAdvisor.advise(
+            stats(15), WeaknessProfile.EMPTY, defaultPlan, emptyMap(),
+            lastGameWasLoss = true
+        )
+        assertEquals(CoachAdvisor.Action.REVIEW_GAMES, advice.action)
+        assertTrue(advice.focuses.any { it.contains("loss") })
+        // The lesson stays visible as a focus even when the loss leads
+        assertTrue(advice.focuses.any { it.startsWith("Current lesson:") })
+    }
+
+    @Test
+    fun `reactions match the result and its context`() {
+        assertTrue(
+            CoachAdvisor.react(GameResult.WIN, newPeak = true, winStreak = 1, calibrating = false)
+                .contains("peak")
+        )
+        assertTrue(
+            CoachAdvisor.react(GameResult.WIN, newPeak = false, winStreak = 4, calibrating = false)
+                .contains("4 in a row")
+        )
+        assertTrue(
+            CoachAdvisor.react(GameResult.LOSS, newPeak = false, winStreak = 0, calibrating = true)
+                .contains("finding your level")
+        )
+        assertTrue(
+            CoachAdvisor.react(GameResult.LOSS, newPeak = false, winStreak = 0, calibrating = false)
+                .contains("practice material")
+        )
+        assertTrue(
+            CoachAdvisor.react(GameResult.DRAW, newPeak = false, winStreak = 0, calibrating = false)
+                .contains("half-point")
+        )
     }
 
     @Test


### PR DESCRIPTION
Implements all three batches from the frontend + UX expert reviews.

## Batch 1 — Safety (the worst first-session failure modes)

- **System back no longer exits the app.** A `BackHandler` mirrors the on-screen Back everywhere; mid-game it asks "Leave the game? Leaving counts as a resignation" instead of silently killing an unfinished game. **Resign now confirms too** — one mis-tap is no longer a recorded loss.
- **CUSTOM corner button** gets a 48dp minimum tap target plus accessibility click labels — it sits inside a tile whose own tap instantly starts a game, so a near-miss must not.
- **First-run default mode is Training**: a brand-new player's instant first game lands in the assisted, coach-visible experience. Rated stays one segmented-control tap away and the choice persists.
- **Itemized ELO at game over**: `ELO +9 → 1237 (+12 without 2 hints, 1 undo)` — the assistance cost is visible, honest, and (as the UX review noted) reveals that hints are cheap, which encourages learning-optimal use.

## Batch 2 — Closing the learning loop

- **Game-over panel**: "Review this game" (primary), "Play again", "Home" — replacing the lone "New Game" button. Review opens the *just-played* game; `ReviewViewModel` now polls while the save/analysis lands (~15s) instead of demanding a manual back-and-retry, which also fixes the Games list's "Analyzing…" dead-end rows.
- **The coach reacts at game over** (Training): one line picked from the result — "New peak — that's real progress." / "That's 4 in a row — you're trending up." / "Every loss is practice material — let's see what this one teaches." (`CoachAdvisor.react`, pure + tested).
- **Lesson completion celebrates**: a distinct bordered card ("Lesson complete! Endgame technique — done. Rai: one thing trained, on to the next.") instead of rendering identically to a routine "Solved!".
- **REVIEW_GAMES is live**: a fresh loss makes the coach's suggested action "Review your last game" — the most coach-like sentence the app can say, and the plumbing already existed.

## Batch 3 — Architecture

- **Sealed `Screen` navigation** with a Bundle `Saver` replaces six independent boolean flags ordered by if-chain: destinations are mutually exclusive by construction, the back logic is one `when`, and the coach's double-refresh on cold start is gone (init refresh removed; refreshes are entry-driven and cancel racing loads).
- **Edge-to-edge**: `enableEdgeToEdge()` + one global `safeDrawing` insets wrapper — ready for the forced edge-to-edge at targetSdk 35, no per-screen work needed.
- **Shared `RaiScreen` scaffold** for the setup-style screens (Play setup, Coach, Games, Settings): one padding convention, one Back affordance, instead of five hand-rolled copies.
- **Font-scale-safe slots**: the game coach line, practice prompt, review detail, and home tiles switch from fixed dp heights to `heightIn(min)` — at 1.5–2× accessibility font scale they grow instead of clipping.
- **"Review" tile renamed "Games"** to match the screen it opens (one name per concept).

Tests: 28 local (EloCalculator 18, CoachAdvisor 10 incl. new loss-suggests-review and reaction cases). Compose screens compile in CI.

Not addressed (from the reviews, deliberately deferred): daily-streak/habit layer, session recaps, dynamic Train-tile subtitle, TalkBack semantics on decorative glyphs, LazyColumn for the games list, i18n/strings.xml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p)_