### PR TITLE
Win-probability move grading + Maia human-like opponent spike

### DIFF
--- a/.github/workflows/calibrate-maia.yml
+++ b/.github/workflows/calibrate-maia.yml
@@ -1,0 +1,94 @@
+name: Calibrate Maia
+
+# Phase-1 spike for human-like opponents: builds desktop lc0, fetches the
+# Maia per-rating nets, and plays them (nodes=1, pure policy — the
+# intended way to probe Maia) against Stockfish UCI_Elo anchors and
+# against RaiEngine at the same nominal label. The report in the "Play
+# calibration matches" step log answers two questions before any Android
+# integration work: does maia-1100 actually measure ~1100, and how does
+# our synthetic band compare to the human-like reference?
+on:
+  workflow_dispatch:
+    inputs:
+      games:
+        description: 'Games per pairing (more = tighter estimate, slower)'
+        required: false
+        default: '12'
+
+permissions:
+  contents: read
+
+env:
+  LC0_TAG: v0.31.2
+
+jobs:
+  calibrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        cache-read-only: true
+
+    - name: Cache lc0 build
+      id: lc0-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/lc0-bin/lc0
+        key: lc0-${{ env.LC0_TAG }}-blas-${{ runner.os }}
+
+    - name: Build lc0 (BLAS backend)
+      if: steps.lc0-cache.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y meson ninja-build libopenblas-dev zlib1g-dev \
+          protobuf-compiler libprotobuf-dev
+        git clone --depth 1 -b "$LC0_TAG" --recurse-submodules \
+          https://github.com/LeelaChessZero/lc0.git ~/lc0-src
+        cd ~/lc0-src
+        ./build.sh release -Dgtest=false -Dblas=true
+        mkdir -p ~/lc0-bin
+        cp build/release/lc0 ~/lc0-bin/lc0
+
+    - name: Fetch Maia weights
+      run: |
+        mkdir -p ~/maia-weights
+        for band in 1100 1500; do
+          curl -sSL -o ~/maia-weights/maia-$band.pb.gz \
+            "https://github.com/CSSLab/maia-chess/raw/master/maia_weights/maia-$band.pb.gz"
+        done
+        ls -la ~/maia-weights
+
+    - name: Install anchor Stockfish
+      run: sudo apt-get update && sudo apt-get install -y stockfish
+
+    - name: Play calibration matches
+      # Inputs reach the shell via env, never ${{ }} inside run:
+      env:
+        GAMES: ${{ github.event.inputs.games || '12' }}
+      run: |
+        ./gradlew testDebugUnitTest \
+          --tests "com.raichess.calibration.MaiaCalibrationTest" \
+          -Draichess.calibrate.maia=true \
+          -Draichess.calibrate.games="$GAMES" \
+          -Dlc0.path="$HOME/lc0-bin/lc0" \
+          -Dmaia.weights.dir="$HOME/maia-weights" \
+          -Dstockfish.path="$(command -v stockfish)" \
+          --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,16 +63,25 @@ android {
     }
 
     testOptions {
-        // Calibration-harness passthrough (see RaiEngineCalibrationTest):
-        // forwards the opt-in flag and Stockfish location from the Gradle
-        // JVM (-D on the command line) into the unit-test JVM, and echoes
-        // test stdout while calibrating so the report lands in the CI log.
+        // Calibration-harness passthrough (see RaiEngineCalibrationTest,
+        // MaiaCalibrationTest): forwards the opt-in flags and engine
+        // locations from the Gradle JVM (-D on the command line) into the
+        // unit-test JVM, and echoes test stdout while calibrating so the
+        // report lands in the CI log.
         unitTests.all { test ->
-            listOf("raichess.calibrate", "raichess.calibrate.games", "stockfish.path")
-                .forEach { key ->
-                    System.getProperty(key)?.let { test.systemProperty(key, it) }
-                }
-            if (System.getProperty("raichess.calibrate") == "true") {
+            listOf(
+                "raichess.calibrate",
+                "raichess.calibrate.maia",
+                "raichess.calibrate.games",
+                "stockfish.path",
+                "lc0.path",
+                "maia.weights.dir"
+            ).forEach { key ->
+                System.getProperty(key)?.let { test.systemProperty(key, it) }
+            }
+            if (System.getProperty("raichess.calibrate") == "true" ||
+                System.getProperty("raichess.calibrate.maia") == "true"
+            ) {
                 test.testLogging.showStandardStreams = true
             }
         }

--- a/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
+++ b/app/src/main/java/com/raichess/domain/model/MoveClassifier.kt
@@ -3,19 +3,20 @@ package com.raichess.domain.model
 import kotlin.math.max
 
 /**
- * Quality verdict for a single played move, per the thresholds in
- * TECHNICAL_PLAN.md §B (Game Analysis Algorithm).
+ * Quality verdict for a single played move. Graded on BOTH centipawn loss
+ * and win-probability drop (see [MoveClassifier.classify]); the labels
+ * below describe the cp component near an even position.
  */
 enum class MoveClassification {
     /** The engine's own first choice. */
     BEST,
-    /** Within 0.6 pawns of best. */
+    /** Close to best, or a swing that barely moves the win chances. */
     GOOD,
-    /** 0.6–1.0 pawn loss. */
+    /** A clear loss of ground. */
     INACCURACY,
-    /** 1.0–3.0 pawn loss. */
+    /** A serious error. */
     MISTAKE,
-    /** 3.0+ pawn loss. */
+    /** A game-changing error. */
     BLUNDER
 }
 
@@ -62,12 +63,58 @@ object MoveClassifier {
     fun lossBetween(before: PositionAnalysis, after: PositionAnalysis): Int =
         centipawnLoss(before.effectiveCp(), -after.effectiveCp())
 
-    fun classify(centipawnLoss: Int, playedEngineBest: Boolean): MoveClassification = when {
-        playedEngineBest -> MoveClassification.BEST
-        centipawnLoss < INACCURACY_THRESHOLD_CP -> MoveClassification.GOOD
-        centipawnLoss < MISTAKE_THRESHOLD_CP -> MoveClassification.INACCURACY
-        centipawnLoss < BLUNDER_THRESHOLD_CP -> MoveClassification.MISTAKE
-        else -> MoveClassification.BLUNDER
+    // Win-probability-drop thresholds, in percentage points (Lichess-style
+    // judgment: ≥10 inaccuracy, ≥20 mistake, ≥30 blunder).
+    const val INACCURACY_DROP_PP = 10
+    const val MISTAKE_DROP_PP = 20
+    const val BLUNDER_DROP_PP = 30
+
+    /**
+     * Percentage points of winning chances thrown away by a move, never
+     * negative. Both evals from the mover's perspective, already capped.
+     */
+    fun winDrop(evalBeforeCp: Int, evalAfterCp: Int): Int =
+        max(0, WinProbability.percent(evalBeforeCp) - WinProbability.percent(evalAfterCp))
+
+    /**
+     * Grade a move from the eval before it and the eval after it (both
+     * from the mover's perspective, already capped).
+     *
+     * Hybrid on purpose — a move is only as bad as BOTH scales agree
+     * (field feedback: a 1.2-pawn "Mistake" at move 3 of an even opening
+     * read as engine preference, not error):
+     * - Centipawns alone over-flag swings that barely change the outcome —
+     *   openings graded by a short search, conversions in won positions,
+     *   shuffling in lost ones. The win-probability drop discounts those.
+     * - Win-probability alone over-flags tiny cp swings in sharp positions
+     *   where the logistic curve is steep. The cp floor discounts those.
+     */
+    fun classify(
+        evalBeforeCp: Int,
+        evalAfterCp: Int,
+        playedEngineBest: Boolean
+    ): MoveClassification {
+        if (playedEngineBest) return MoveClassification.BEST
+        val cpLoss = centipawnLoss(evalBeforeCp, evalAfterCp)
+        val drop = winDrop(evalBeforeCp, evalAfterCp)
+        val cpSeverity = when {
+            cpLoss < INACCURACY_THRESHOLD_CP -> 0
+            cpLoss < MISTAKE_THRESHOLD_CP -> 1
+            cpLoss < BLUNDER_THRESHOLD_CP -> 2
+            else -> 3
+        }
+        val dropSeverity = when {
+            drop < INACCURACY_DROP_PP -> 0
+            drop < MISTAKE_DROP_PP -> 1
+            drop < BLUNDER_DROP_PP -> 2
+            else -> 3
+        }
+        return when (minOf(cpSeverity, dropSeverity)) {
+            0 -> MoveClassification.GOOD
+            1 -> MoveClassification.INACCURACY
+            2 -> MoveClassification.MISTAKE
+            else -> MoveClassification.BLUNDER
+        }
     }
 
     /**

--- a/app/src/main/java/com/raichess/domain/usecase/GameAnalyzer.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/GameAnalyzer.kt
@@ -120,7 +120,11 @@ class GameAnalyzer(
                 evaluationCp = if (step.whiteToMove) evalBeforeStm else -evalBeforeStm,
                 bestMoveLan = step.analysis.bestMoveLan,
                 centipawnLoss = if (isPlayerMove) loss else null,
-                classification = if (isPlayerMove) MoveClassifier.classify(loss, playedBest) else null,
+                classification = if (isPlayerMove) {
+                    MoveClassifier.classify(evalBeforeStm, -evalAfterNextStm, playedBest)
+                } else {
+                    null
+                },
                 themes = themes,
                 depth = step.analysis.depth
             )
@@ -142,8 +146,10 @@ class GameAnalyzer(
          * Bump when the analysis semantics change (thresholds, eval
          * conventions, tagging) so stored rows can be found and re-analyzed.
          * v2: theme tagging (Phase B).
+         * v3: hybrid cp + win-probability-drop classification — stored
+         * grades change, so history re-analyzes to match.
          */
-        const val VERSION = 2
+        const val VERSION = 3
 
         /** Per-position budget: deep enough to grade honestly, ~15s for a 60-ply game. */
         const val DEFAULT_MOVE_TIME_MS = 250L

--- a/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/game/GameViewModel.kt
@@ -606,7 +606,8 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                         if (afterMove != null) {
                             playerMoveLoss = MoveClassifier.lossBetween(baseline, afterMove)
                             playerMoveRating = MoveClassifier.classify(
-                                playerMoveLoss,
+                                evalBeforeCp = baseline.effectiveCp(),
+                                evalAfterCp = -afterMove.effectiveCp(),
                                 playedEngineBest = playerMoveLan != null &&
                                     playerMoveLan == baseline.bestMoveLan
                             )

--- a/app/src/test/java/com/raichess/calibration/MaiaCalibrationTest.kt
+++ b/app/src/test/java/com/raichess/calibration/MaiaCalibrationTest.kt
@@ -1,0 +1,189 @@
+package com.raichess.calibration
+
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.Side
+import com.github.bhlangonijr.chesslib.move.MoveGenerator
+import com.raichess.data.engine.RaiEngine
+import java.io.File
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import kotlin.math.log10
+import kotlin.math.roundToInt
+import kotlin.random.Random
+
+/**
+ * Phase-1 spike for human-like opponents: measures what the Maia neural
+ * nets (CSSLab, per-rating human-move predictors) actually play like when
+ * probed the intended way (lc0, `go nodes 1` — pure policy, no search).
+ *
+ * Two measurements per bundled net:
+ * 1. vs Stockfish at known UCI_Elo anchors → implied rating, same
+ *    methodology as [RaiEngineCalibrationTest], so the two tables are
+ *    directly comparable.
+ * 2. vs RaiEngine at the net's nominal rating → is our synthetic band
+ *    stronger, weaker, or on par with the human-like reference?
+ *
+ * Opt-in and CI-only (needs desktop lc0 + weights + Stockfish): run via
+ * the calibrate-maia workflow, or locally with
+ * `-Draichess.calibrate.maia=true -Dlc0.path=... -Dmaia.weights.dir=...
+ *  -Dstockfish.path=...`.
+ */
+class MaiaCalibrationTest {
+
+    @Test
+    fun `measure implied elo of maia nets against stockfish anchors and raiengine`() {
+        assumeTrue(
+            "maia calibration is opt-in: run with -Draichess.calibrate.maia=true",
+            System.getProperty("raichess.calibrate.maia") == "true"
+        )
+        val lc0Path = System.getProperty("lc0.path") ?: "lc0"
+        val weightsDir = File(System.getProperty("maia.weights.dir") ?: ".")
+        val stockfishPath = System.getProperty("stockfish.path") ?: "stockfish"
+        val gamesPerPairing =
+            (System.getProperty("raichess.calibrate.games") ?: "$DEFAULT_GAMES").toInt()
+
+        val report = StringBuilder()
+        report.appendLine("Maia calibration (lc0=$lc0Path, nodes=1)")
+        report.appendLine("net       | opponent        | games | score | implied ELO")
+        report.appendLine("----------+-----------------+-------+-------+------------")
+
+        var totalGames = 0
+        for (band in MAIA_BANDS) {
+            val weights = File(weightsDir, "maia-$band.pb.gz")
+            if (!weights.isFile) {
+                report.appendLine("maia-$band | MISSING WEIGHTS ($weights) — skipped")
+                continue
+            }
+
+            // vs Stockfish anchors: implied rating from match score
+            for (anchor in ANCHORS) {
+                UciProcessClient(listOf(lc0Path, "--weights=${weights.absolutePath}"))
+                    .use { maia ->
+                        maia.start()
+                        UciProcessClient(stockfishPath).use { stockfish ->
+                            stockfish.startLimitedTo(anchor)
+                            var score = 0.0
+                            repeat(gamesPerPairing) { game ->
+                                score += playGame(
+                                    white = { fen ->
+                                        if (game % 2 == 0) maia.bestMoveNodes(fen, 1)
+                                        else stockfish.bestMove(fen, SF_MOVE_TIME_MS)
+                                    },
+                                    black = { fen ->
+                                        if (game % 2 == 0) stockfish.bestMove(fen, SF_MOVE_TIME_MS)
+                                        else maia.bestMoveNodes(fen, 1)
+                                    },
+                                    scoredSideIsWhite = game % 2 == 0
+                                )
+                                totalGames++
+                            }
+                            val fraction = score / gamesPerPairing
+                            report.appendLine(
+                                "maia-%d | Stockfish %5d | %5d | %.3f | %11s".format(
+                                    band, anchor, gamesPerPairing, fraction,
+                                    impliedEloText(anchor, fraction)
+                                )
+                            )
+                        }
+                    }
+            }
+
+            // vs RaiEngine at the same nominal rating: >0.5 means Maia is
+            // stronger than our synthetic band of the same label
+            UciProcessClient(listOf(lc0Path, "--weights=${weights.absolutePath}"))
+                .use { maia ->
+                    maia.start()
+                    var score = 0.0
+                    repeat(gamesPerPairing) { game ->
+                        val rai = RaiEngine(
+                            targetElo = band,
+                            random = Random(band * 7919 + game)
+                        )
+                        score += playGame(
+                            white = { fen ->
+                                if (game % 2 == 0) maia.bestMoveNodes(fen, 1)
+                                else raiMove(rai, fen)
+                            },
+                            black = { fen ->
+                                if (game % 2 == 0) raiMove(rai, fen)
+                                else maia.bestMoveNodes(fen, 1)
+                            },
+                            scoredSideIsWhite = game % 2 == 0
+                        )
+                        totalGames++
+                    }
+                    report.appendLine(
+                        "maia-%d | RaiEngine %5d | %5d | %.3f | %11s".format(
+                            band, band, gamesPerPairing, score / gamesPerPairing,
+                            "(vs same label)"
+                        )
+                    )
+                }
+        }
+
+        report.appendLine()
+        report.appendLine("Anchors floor at Stockfish's UCI_Elo minimum (1320).")
+        println(report)
+        assert(totalGames > 0) { "no games played — are the weights present?" }
+    }
+
+    /** RaiEngine as a UCI-shaped move provider over a FEN. */
+    private fun raiMove(rai: RaiEngine, fen: String): String? {
+        val board = Board().apply { loadFromFen(fen) }
+        return rai.selectMove(board)?.toString()?.lowercase()
+    }
+
+    /**
+     * One game between two move providers; returns the scored side's
+     * result (1 / 0.5 / 0). Move-limit games adjudicate as draws, same as
+     * [RaiEngineCalibrationTest].
+     */
+    private fun playGame(
+        white: (String) -> String?,
+        black: (String) -> String?,
+        scoredSideIsWhite: Boolean
+    ): Double {
+        val board = Board()
+        var plies = 0
+        while (plies < MAX_PLIES) {
+            if (board.isMated) {
+                val scoredToMove = (board.sideToMove == Side.WHITE) == scoredSideIsWhite
+                return if (scoredToMove) 0.0 else 1.0
+            }
+            if (board.isDraw) return 0.5
+
+            val provider = if (board.sideToMove == Side.WHITE) white else black
+            val lan = provider(board.fen) ?: return 0.5
+            val move = MoveGenerator.generateLegalMoves(board)
+                .firstOrNull { it.toString().lowercase() == lan }
+                ?: error("engine played illegal move $lan in ${board.fen}")
+            board.doMove(move)
+            plies++
+        }
+        return 0.5
+    }
+
+    /** Match score -> implied rating; clamped so a shutout stays finite. */
+    private fun impliedEloText(anchor: Int, fraction: Double): String {
+        val clamped = fraction.coerceIn(CLAMP_MIN, 1.0 - CLAMP_MIN)
+        val implied = anchor + (-400.0 * log10(1.0 / clamped - 1.0)).roundToInt()
+        return when {
+            fraction <= CLAMP_MIN -> "<= $implied"
+            fraction >= 1.0 - CLAMP_MIN -> ">= $implied"
+            else -> "$implied"
+        }
+    }
+
+    companion object {
+        // The bands the app would bundle first: 1100 covers the top of the
+        // RaiEngine range, 1500 the middle of the Stockfish band
+        private val MAIA_BANDS = intArrayOf(1100, 1500)
+
+        private val ANCHORS = intArrayOf(1320, 1500)
+
+        private const val DEFAULT_GAMES = 12
+        private const val SF_MOVE_TIME_MS = 60L
+        private const val MAX_PLIES = 240
+        private const val CLAMP_MIN = 0.02
+    }
+}

--- a/app/src/test/java/com/raichess/calibration/UciProcessClient.kt
+++ b/app/src/test/java/com/raichess/calibration/UciProcessClient.kt
@@ -3,31 +3,45 @@ package com.raichess.calibration
 import java.util.concurrent.TimeUnit
 
 /**
- * Minimal blocking UCI client over a local engine process, used only by the
- * opt-in calibration harness ([RaiEngineCalibrationTest]) — the app itself
- * never spawns desktop processes. Single-threaded by design: every command
- * waits for its reply before the next is sent.
+ * Minimal blocking UCI client over a local engine process, used only by
+ * the opt-in calibration harnesses ([RaiEngineCalibrationTest],
+ * [MaiaCalibrationTest]) — the app itself never spawns desktop processes.
+ * Single-threaded by design: every command waits for its reply before the
+ * next is sent. Works with any UCI engine (Stockfish, lc0+Maia, ...);
+ * engines that take their configuration on the command line (lc0's
+ * `--weights=`) pass it via [command].
  */
-class UciProcessClient(enginePath: String) : AutoCloseable {
+class UciProcessClient(command: List<String>) : AutoCloseable {
 
-    private val process = ProcessBuilder(enginePath)
+    constructor(enginePath: String) : this(listOf(enginePath))
+
+    private val process = ProcessBuilder(command)
         .redirectErrorStream(true)
         .start()
     private val writer = process.outputStream.bufferedWriter()
     private val reader = process.inputStream.bufferedReader()
 
-    /**
-     * UCI handshake plus strength limiting to [elo] via UCI_Elo (supported
-     * by Stockfish 11+; modern builds floor at 1320).
-     */
-    fun startLimitedTo(elo: Int) {
+    /** UCI handshake, then apply [options], then wait until ready. */
+    fun start(options: Map<String, String> = emptyMap()) {
         send("uci")
         waitFor("uciok")
-        send("setoption name UCI_LimitStrength value true")
-        send("setoption name UCI_Elo value $elo")
+        options.forEach { (name, value) ->
+            send("setoption name $name value $value")
+        }
         send("isready")
         waitFor("readyok")
     }
+
+    /**
+     * Handshake plus strength limiting to [elo] via UCI_Elo (supported by
+     * Stockfish 11+; modern builds floor at 1320).
+     */
+    fun startLimitedTo(elo: Int) = start(
+        mapOf(
+            "UCI_LimitStrength" to "true",
+            "UCI_Elo" to "$elo"
+        )
+    )
 
     fun newGame() {
         send("ucinewgame")
@@ -39,9 +53,19 @@ class UciProcessClient(enginePath: String) : AutoCloseable {
      * Search [fen] for [moveTimeMs] and return the chosen move in lowercase
      * LAN, or null when the engine has no move (mate/stalemate).
      */
-    fun bestMove(fen: String, moveTimeMs: Long): String? {
+    fun bestMove(fen: String, moveTimeMs: Long): String? =
+        search(fen, "go movetime $moveTimeMs")
+
+    /**
+     * Fixed-node search. `nodes 1` is how Maia is meant to be played: one
+     * evaluation of the root, move picked from the policy head alone.
+     */
+    fun bestMoveNodes(fen: String, nodes: Int): String? =
+        search(fen, "go nodes $nodes")
+
+    private fun search(fen: String, goCommand: String): String? {
         send("position fen $fen")
-        send("go movetime $moveTimeMs")
+        send(goCommand)
         val line = waitFor("bestmove")
         return line.split(" ").getOrNull(1)?.lowercase()?.takeIf { it != "(none)" }
     }

--- a/app/src/test/java/com/raichess/domain/model/MoveClassifierTest.kt
+++ b/app/src/test/java/com/raichess/domain/model/MoveClassifierTest.kt
@@ -13,27 +13,73 @@ class MoveClassifierTest {
     }
 
     @Test
-    fun `classification thresholds match the technical plan`() {
-        // Good: within 0.3 pawns of best
-        assertEquals(MoveClassification.GOOD, MoveClassifier.classify(0, playedEngineBest = false))
-        assertEquals(MoveClassification.GOOD, MoveClassifier.classify(59, playedEngineBest = false))
-        // Inaccuracy: 0.3-1.0 pawn loss
-        assertEquals(MoveClassification.INACCURACY, MoveClassifier.classify(60, playedEngineBest = false))
-        assertEquals(MoveClassification.INACCURACY, MoveClassifier.classify(99, playedEngineBest = false))
-        // Mistake: 1.0-3.0 pawn loss
-        assertEquals(MoveClassification.MISTAKE, MoveClassifier.classify(100, playedEngineBest = false))
-        assertEquals(MoveClassification.MISTAKE, MoveClassifier.classify(299, playedEngineBest = false))
-        // Blunder: 3.0+ pawn loss
-        assertEquals(MoveClassification.BLUNDER, MoveClassifier.classify(300, playedEngineBest = false))
-        assertEquals(MoveClassification.BLUNDER, MoveClassifier.classify(2000, playedEngineBest = false))
+    fun `win drop is the winning-chances loss in percentage points`() {
+        assertEquals(0, MoveClassifier.winDrop(evalBeforeCp = 0, evalAfterCp = 0))
+        // Never negative even when the move improved the position
+        assertEquals(0, MoveClassifier.winDrop(evalBeforeCp = -50, evalAfterCp = 100))
+        // Equality to -900 is a collapse of most of the win chances
+        val collapse = MoveClassifier.winDrop(evalBeforeCp = 0, evalAfterCp = -900)
+        org.junit.Assert.assertTrue("expected a large drop, got $collapse", collapse >= 40)
+    }
+
+    @Test
+    fun `near equality the cp thresholds still gate small losses`() {
+        // Small cp losses stay GOOD regardless of position
+        assertEquals(
+            MoveClassification.GOOD,
+            MoveClassifier.classify(evalBeforeCp = 0, evalAfterCp = -59, playedEngineBest = false)
+        )
+        // A hung queen at equality is a blunder on both scales
+        assertEquals(
+            MoveClassification.BLUNDER,
+            MoveClassifier.classify(evalBeforeCp = 0, evalAfterCp = -900, playedEngineBest = false)
+        )
+    }
+
+    @Test
+    fun `a small opening-style swing is an inaccuracy, not a mistake`() {
+        // Field feedback: 1.2 pawns at move 3 of an even game was labelled
+        // "Mistake" — but it only moves the win chances ~11 points, which
+        // is engine preference territory, not a serious error
+        assertEquals(
+            MoveClassification.INACCURACY,
+            MoveClassifier.classify(evalBeforeCp = 20, evalAfterCp = -100, playedEngineBest = false)
+        )
+        // A 2.5-pawn swing at equality genuinely changes the game: mistake
+        assertEquals(
+            MoveClassification.MISTAKE,
+            MoveClassifier.classify(evalBeforeCp = 0, evalAfterCp = -250, playedEngineBest = false)
+        )
+    }
+
+    @Test
+    fun `swings in decided positions are discounted`() {
+        // Sloppy conversion while completely winning: +900 to +600 is
+        // three pawns of eval but almost no win-chance change — not a
+        // mistake worth nagging
+        assertEquals(
+            MoveClassification.GOOD,
+            MoveClassifier.classify(evalBeforeCp = 900, evalAfterCp = 600, playedEngineBest = false)
+        )
+        // Same in a lost position: -600 to -900 changes nothing
+        assertEquals(
+            MoveClassification.GOOD,
+            MoveClassifier.classify(evalBeforeCp = -600, evalAfterCp = -900, playedEngineBest = false)
+        )
     }
 
     @Test
     fun `playing the engine best move is BEST regardless of loss`() {
         // In practice a best move has ~0 loss, but eval noise between
         // searches must not demote the engine's own first choice
-        assertEquals(MoveClassification.BEST, MoveClassifier.classify(0, playedEngineBest = true))
-        assertEquals(MoveClassification.BEST, MoveClassifier.classify(45, playedEngineBest = true))
+        assertEquals(
+            MoveClassification.BEST,
+            MoveClassifier.classify(evalBeforeCp = 0, evalAfterCp = 0, playedEngineBest = true)
+        )
+        assertEquals(
+            MoveClassification.BEST,
+            MoveClassifier.classify(evalBeforeCp = 0, evalAfterCp = -45, playedEngineBest = true)
+        )
     }
 
     @Test

--- a/app/src/test/java/com/raichess/domain/usecase/GameAnalyzerTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/GameAnalyzerTest.kt
@@ -84,12 +84,16 @@ class GameAnalyzerTest {
         assertEquals(4, engine.calls)
 
         val f3 = report.moves[0]
-        // before +20, after: Black's +50 → White -50; loss 70 → inaccuracy
+        // before +20, after: Black's +50 → White -50; loss 70. Under the
+        // hybrid classifier that's only ~7 points of win chance near
+        // equality — below the inaccuracy drop threshold, so GOOD (the cp
+        // loss alone would have said inaccuracy; see MoveClassifierTest)
         assertEquals(70, f3.centipawnLoss)
-        assertEquals(MoveClassification.INACCURACY, f3.classification)
+        assertEquals(MoveClassification.GOOD, f3.classification)
 
         val g4 = report.moves[2]
-        // before -80; after: mate-in-1 for Black (+1000 capped) → White -1000
+        // before -80; after: mate-in-1 for Black (+1000 capped) → White
+        // -1000; a ~41-point win-chance collapse — blunder on both scales
         assertEquals(920, g4.centipawnLoss)
         assertEquals(MoveClassification.BLUNDER, g4.classification)
 


### PR DESCRIPTION
Two rounds on one branch (the first was still open when the pivot work started):

# Round 1 — Grade moves by win-probability drop, not raw centipawns alone

Fixes the "mistakes feel arbitrary" field report: *"e5 instead of Nf3 at move 3 — Mistake, lost 1.2 pawns"* was an engine style opinion presented as an error.

A move's severity is now the **lesser** of two scales (Lichess-style hybrid):
- **Centipawn loss** (existing 60/100/300 thresholds) — floors out tiny swings in sharp positions.
- **Win-probability drop** (new: ≥10pp inaccuracy / ≥20pp mistake / ≥30pp blunder via the existing `WinProbability` logistic) — discounts swings that barely change the outcome.

| Situation | Before | After |
|---|---|---|
| ~120cp swing at equality, move 3 (the screenshot) | Mistake | **Inaccuracy** — drops out of the mistakes review |
| +900 → +600 while completely winning | Mistake | **Good** |
| −600 → −900 in a lost position | Blunder | **Good** |
| Hung queen at equality | Blunder | Blunder |

Applied to both the live coach grade and post-game analysis. `GameAnalyzer.VERSION` → 3, so stored games re-analyze under the new semantics on next launch. 9 `MoveClassifierTest` tests with hand-verified curve values.

# Round 2 — Maia calibration spike (Phase 1 of the offline-coach pivot)

Before integrating human-like opponents into the app, measure them. The Maia nets (CSSLab) are per-rating human-move predictors trained on real games at each band — the research-backed answer to "engine bots blunder like machines, not people."

- `UciProcessClient` generalized: list-form commands (`lc0 --weights=…`), arbitrary UCI option maps, and fixed-node search (`go nodes 1` — the intended Maia probe: one evaluation, move straight from the policy head). Smoke-tested against a real Stockfish locally.
- `MaiaCalibrationTest` (opt-in, CI-only): plays **maia-1100** and **maia-1500** against Stockfish `UCI_Elo` anchors (implied-rating table, same methodology as the RaiEngine harness so the numbers are directly comparable) *and* against RaiEngine at the same nominal label — answering both "does maia-1100 measure ~1100?" and "is our synthetic 1100 stronger or weaker than the human-like reference?"
- New **Calibrate Maia** manual workflow: builds desktop lc0 (BLAS backend, cached by release tag), fetches the Maia weights, installs Stockfish, plays the matches. Report in the step log.

Run it once after merge (workflows appear in Actions only from `main`). Note the lc0 CI build couldn't be rehearsed from the sandbox — if the first run trips on a build dependency, it's a one-line workflow fix. The spike's results decide the Android integration path (lc0 NDK build vs ONNX Runtime) for the real opponent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p