### PR TITLE
Maia opponents + eased seam + drills that accept any good move + multi-move puzzle variety

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -70,7 +70,7 @@ jobs:
         path: |
           app/src/main/jniLibs
           app/src/main/assets/maia
-        key: lc0-android-${{ env.LC0_TAG }}-maia-v2
+        key: lc0-android-${{ env.LC0_TAG }}-maia-v3
 
     - name: Cross-build lc0 for Android
       if: steps.lc0-android-cache.outputs.cache-hit != 'true'
@@ -103,10 +103,15 @@ jobs:
 
     - name: Fetch Maia weights
       if: steps.lc0-android-cache.outputs.cache-hit != 'true'
+      # Stored with a .net extension: .gz-suffixed assets were silently
+      # absent from the packaged APK (first integration run), so the asset
+      # name avoids the special-cased extension entirely. The content is
+      # still the gzipped net; MaiaEngine restores the .pb.gz name when it
+      # extracts to filesDir for lc0.
       run: |
         mkdir -p app/src/main/assets/maia
         for band in $MAIA_BANDS; do
-          curl -sSL -o "app/src/main/assets/maia/maia-$band.pb.gz" \
+          curl -sSL -o "app/src/main/assets/maia/maia-$band.net" \
             "https://github.com/CSSLab/maia-chess/raw/master/maia_weights/maia-$band.pb.gz"
         done
         ls -la app/src/main/assets/maia
@@ -130,9 +135,11 @@ jobs:
             exit 1
           fi
         done
+        echo "APK maia assets:"
+        unzip -l "$APK" | grep 'assets/maia' || true
         for band in $MAIA_BANDS; do
-          if ! unzip -l "$APK" | grep -q "assets/maia/maia-$band.pb.gz"; then
-            echo "::error::maia-$band.pb.gz missing from assets — the weights step broke"
+          if ! unzip -l "$APK" | grep -q "assets/maia/maia-$band.net"; then
+            echo "::error::maia-$band.net missing from assets — the weights step broke"
             exit 1
           fi
         done

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -70,13 +70,19 @@ jobs:
         path: |
           app/src/main/jniLibs
           app/src/main/assets/maia
-        key: lc0-android-${{ env.LC0_TAG }}-maia-v1
+        key: lc0-android-${{ env.LC0_TAG }}-maia-v2
 
     - name: Cross-build lc0 for Android
       if: steps.lc0-android-cache.outputs.cache-hit != 'true'
+      # v0.31.2's CPU path is the 'blas' backend; with every BLAS library
+      # disabled it builds on Eigen, which meson pulls as a header-only
+      # wrap subproject — ideal for cross-compilation. Protos compile via
+      # a bundled python script, so no protobuf toolchain is needed. The
+      # x86-only ISA options (popcnt/f16c/pext) and GPU/vendor backends
+      # are switched off explicitly for the ARM cross target.
       run: |
         sudo apt-get update
-        sudo apt-get install -y meson ninja-build protobuf-compiler
+        sudo apt-get install -y meson ninja-build
         export PATH="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
         git clone --depth 1 -b "$LC0_TAG" --recurse-submodules \
           https://github.com/LeelaChessZero/lc0.git ~/lc0-src
@@ -85,7 +91,11 @@ jobs:
           meson setup "build-$abi" \
             --cross-file "$GITHUB_WORKSPACE/tools/lc0-android/$abi.txt" \
             --buildtype=release \
-            -Dgtest=false -Dblas=false -Deigen=true -Dopencl=false
+            -Dgtest=false -Dblas=true \
+            -Dmkl=false -Dopenblas=false -Daccelerate=false -Ddnnl=false \
+            -Dopencl=false -Dcudnn=false -Dplain_cuda=false -Dnative_cuda=false \
+            -Ddx=false -Dispc=false -Dtensorflow=false -Donednn=false \
+            -Dpopcnt=false -Df16c=false -Dpext=false
           ninja -C "build-$abi" lc0
           mkdir -p "$GITHUB_WORKSPACE/app/src/main/jniLibs/$abi"
           cp "build-$abi/lc0" "$GITHUB_WORKSPACE/app/src/main/jniLibs/$abi/liblc0.so"

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -29,6 +29,10 @@ on:
       - 'gradlew.bat'
       - '.github/workflows/**'
 
+env:
+  LC0_TAG: v0.31.2
+  MAIA_BANDS: "1100 1200 1300 1400 1500"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -54,10 +58,54 @@ jobs:
       with:
         cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
 
+    # ---- Maia opponents: native lc0 + per-rating nets --------------------
+    # lc0 cross-compiles per ABI (Eigen CPU backend — header-only, no BLAS
+    # to cross-build) and lands in jniLibs like the Stockfish binary; the
+    # Maia weights land in assets. Both cached by lc0 tag.
+
+    - name: Cache lc0 Android binaries
+      id: lc0-android-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          app/src/main/jniLibs
+          app/src/main/assets/maia
+        key: lc0-android-${{ env.LC0_TAG }}-maia-v1
+
+    - name: Cross-build lc0 for Android
+      if: steps.lc0-android-cache.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y meson ninja-build protobuf-compiler
+        export PATH="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
+        git clone --depth 1 -b "$LC0_TAG" --recurse-submodules \
+          https://github.com/LeelaChessZero/lc0.git ~/lc0-src
+        cd ~/lc0-src
+        for abi in arm64-v8a armeabi-v7a; do
+          meson setup "build-$abi" \
+            --cross-file "$GITHUB_WORKSPACE/tools/lc0-android/$abi.txt" \
+            --buildtype=release \
+            -Dgtest=false -Dblas=false -Deigen=true -Dopencl=false
+          ninja -C "build-$abi" lc0
+          mkdir -p "$GITHUB_WORKSPACE/app/src/main/jniLibs/$abi"
+          cp "build-$abi/lc0" "$GITHUB_WORKSPACE/app/src/main/jniLibs/$abi/liblc0.so"
+        done
+
+    - name: Fetch Maia weights
+      if: steps.lc0-android-cache.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p app/src/main/assets/maia
+        for band in $MAIA_BANDS; do
+          curl -sSL -o "app/src/main/assets/maia/maia-$band.pb.gz" \
+            "https://github.com/CSSLab/maia-chess/raw/master/maia_weights/maia-$band.pb.gz"
+        done
+        ls -la app/src/main/assets/maia
+    # ----------------------------------------------------------------------
+
     - name: Build with Gradle
       run: ./gradlew assembleDebug --stacktrace
 
-    - name: Verify native Stockfish is packaged
+    - name: Verify native engines and Maia nets are packaged
       run: |
         APK=app/build/outputs/apk/debug/app-debug.apk
         echo "APK native libs:"
@@ -67,8 +115,18 @@ jobs:
             echo "::error::libstockfish.so missing for $abi — the executable-as-jniLib packaging broke"
             exit 1
           fi
+          if ! unzip -l "$APK" | grep -q "lib/$abi/liblc0.so"; then
+            echo "::error::liblc0.so missing for $abi — the lc0 cross-build or jniLibs packaging broke"
+            exit 1
+          fi
         done
-        echo "libstockfish.so present for all ABIs"
+        for band in $MAIA_BANDS; do
+          if ! unzip -l "$APK" | grep -q "assets/maia/maia-$band.pb.gz"; then
+            echo "::error::maia-$band.pb.gz missing from assets — the weights step broke"
+            exit 1
+          fi
+        done
+        echo "libstockfish.so, liblc0.so, and all Maia nets present"
 
     - name: Run unit tests
       run: ./gradlew testDebugUnitTest --stacktrace

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ __pycache__/
 # The committed debug keystore is intentional (stable APK signature so
 # updates preserve app data); see app/build.gradle.kts signingConfigs
 !app/debug.keystore
+
+# CI-generated native engines + Maia nets (see android-build.yml)
+app/src/main/jniLibs/
+app/src/main/assets/maia/

--- a/app/src/main/java/com/raichess/data/database/Entities.kt
+++ b/app/src/main/java/com/raichess/data/database/Entities.kt
@@ -90,6 +90,14 @@ data class PositionEntity(
     val classification: String?,
     /** Comma-separated theme tags (hanging_piece, missed_fork, ...); filled by the tagging phase. */
     val themes: String = "",
+    /**
+     * Space-separated LAN moves that are ~as good as [bestMove] (MultiPV
+     * mining, analyzer v4+) — a drill accepts any of them, because an
+     * open position often has several fine moves and demanding the
+     * engine's exact pick reads as arbitrary. Empty for older rows and
+     * for AI moves.
+     */
+    val acceptableMoves: String = "",
     /** Search depth the verdict came from. */
     val analysisDepth: Int,
     /** Version of the analysis pipeline that wrote this row, for re-analysis. */

--- a/app/src/main/java/com/raichess/data/database/GameDao.kt
+++ b/app/src/main/java/com/raichess/data/database/GameDao.kt
@@ -21,6 +21,9 @@ data class MistakeDrillRow(
     val fen: String,
     val bestMove: String,
     val movePlayed: String,
+    val centipawnLoss: Int,
+    /** Space-separated LAN alternates accepted alongside [bestMove]. */
+    val acceptableMoves: String,
     val themes: String
 )
 
@@ -64,7 +67,9 @@ interface GameDao {
      */
     @Query(
         "SELECT p.gameId AS gameId, p.ply AS ply, p.fen AS fen, " +
-            "p.bestMove AS bestMove, p.movePlayed AS movePlayed, p.themes AS themes " +
+            "p.bestMove AS bestMove, p.movePlayed AS movePlayed, " +
+            "p.centipawnLoss AS centipawnLoss, " +
+            "p.acceptableMoves AS acceptableMoves, p.themes AS themes " +
             "FROM positions p JOIN games g ON p.gameId = g.id " +
             "WHERE p.isPlayerMove = 1 AND p.centipawnLoss >= :minLossCp " +
             "AND p.bestMove IS NOT NULL AND p.analysisDepth >= :minDepth " +

--- a/app/src/main/java/com/raichess/data/database/RaiChessDatabase.kt
+++ b/app/src/main/java/com/raichess/data/database/RaiChessDatabase.kt
@@ -4,18 +4,21 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
  * App database: game history, per-move analysis, and practice positions —
  * the storage layer of the coaching roadmap (TECHNICAL_PLAN.md Phase 1/3).
  *
- * NOTE for the next schema bump: there is deliberately no
+ * NOTE for every schema bump: there is deliberately no
  * fallbackToDestructiveMigration() — this data is the user's game history,
- * so version 2 must ship a real Migration or the app will crash on update.
+ * so each new version must ship a real Migration or the app will crash on
+ * update. v2: positions.acceptableMoves (drill alternatives).
  */
 @Database(
     entities = [GameEntity::class, PositionEntity::class, PracticePositionEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 abstract class RaiChessDatabase : RoomDatabase() {
@@ -26,13 +29,21 @@ abstract class RaiChessDatabase : RoomDatabase() {
     companion object {
         @Volatile private var instance: RaiChessDatabase? = null
 
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE positions ADD COLUMN acceptableMoves TEXT NOT NULL DEFAULT ''"
+                )
+            }
+        }
+
         fun get(context: Context): RaiChessDatabase =
             instance ?: synchronized(this) {
                 instance ?: Room.databaseBuilder(
                     context.applicationContext,
                     RaiChessDatabase::class.java,
                     "raichess.db"
-                ).build().also { instance = it }
+                ).addMigrations(MIGRATION_1_2).build().also { instance = it }
             }
     }
 }

--- a/app/src/main/java/com/raichess/data/engine/ChessEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/ChessEngine.kt
@@ -46,6 +46,17 @@ interface ChessEngine {
     fun analyze(board: Board, moveTimeMs: Long): PositionAnalysis? = null
 
     /**
+     * Like [analyze] but returning the top [multiPv] continuations, best
+     * first. Powers "several moves are fine here" judgments (drill
+     * alternatives): each entry's eval is from the same search, same
+     * side-to-move perspective, so entries are directly comparable.
+     * Default: the single best line — implementations without MultiPV
+     * support (RaiEngine, Maia) degrade to that gracefully.
+     */
+    fun analyzeTop(board: Board, moveTimeMs: Long, multiPv: Int): List<PositionAnalysis> =
+        listOfNotNull(analyze(board, moveTimeMs))
+
+    /**
      * Short human-readable label for the engine currently producing moves,
      * for a UI indicator. May change across [selectMove] calls if a stronger
      * engine degrades to a weaker one — e.g. [StockfishWasmEngine] reports

--- a/app/src/main/java/com/raichess/data/engine/EngineFactory.kt
+++ b/app/src/main/java/com/raichess/data/engine/EngineFactory.kt
@@ -4,48 +4,73 @@ import android.content.Context
 import com.raichess.data.diagnostics.EngineDiagnostics
 
 /**
- * Chooses the opponent engine for a target ELO.
+ * Chooses the opponent engine for a target ELO. Three bands:
  *
- * The bundled Stockfish is strength-limited via `Skill Level` (0–20), and even
- * at Skill Level 0 it plays around a ~1300 club level — too strong to convince
- * as a true beginner. The near-random beginner band is exactly what the tunable
- * [RaiEngine] is for, so the low band uses RaiEngine and the strong band uses
- * Stockfish. The Stockfish engine also carries a RaiEngine fallback in case the
- * WASM/WebView bridge fails on a given device.
+ * - Below 1100: [RaiEngine]. The near-random beginner bot is the point —
+ *   nothing else can credibly play that weak.
+ * - 1100–1599: [MaiaEngine] — human-like neural nets trained on real
+ *   games at each rating. CI calibration showed maia-1100 beating our
+ *   synthetic "1100" 12-0 while measuring near its label; this band is
+ *   where "plays like a person" matters most.
+ * - 1600+: Stockfish, strength-limited via Skill Level (native binary
+ *   preferred, WASM fallback).
+ *
+ * Every engine carries a RaiEngine fallback so play never breaks; when
+ * the Maia assets aren't in the build (local dev without the CI weights
+ * step) the band falls back to the pre-Maia routing.
  */
 object EngineFactory {
 
-    // Skill Level 0 is roughly where Stockfish stops feeling like a beginner
-    // (~1300). Below this, RaiEngine gives a more convincing weak opponent.
-    const val STOCKFISH_MIN_ELO = 1350
+    /** Stockfish takes over where Maia's bundled nets end. */
+    const val STOCKFISH_MIN_ELO = 1600
+
+    /**
+     * The pre-Maia Stockfish floor, still used when the Maia assets are
+     * absent: Skill Level 0 plays ~1300, so 1350+ went to Stockfish and
+     * everything below to RaiEngine.
+     */
+    const val LEGACY_STOCKFISH_MIN_ELO = 1350
 
     /** Pure band-selection predicate, extracted for unit testing. */
     fun usesStockfish(targetElo: Int): Boolean = targetElo >= STOCKFISH_MIN_ELO
 
     fun create(context: Context, targetElo: Int): ChessEngine {
         val stockfish = usesStockfish(targetElo)
-        val native = stockfish && StockfishNativeEngine.isAvailable(context)
+        val maiaBand = MaiaEngine.netBandFor(targetElo)
+        val maia = maiaBand != null && MaiaEngine.isAvailable(context, maiaBand)
+        // No Maia in this build: the band splits the old way (1350+
+        // Stockfish, below RaiEngine)
+        val legacyStockfish = !stockfish && !maia && targetElo >= LEGACY_STOCKFISH_MIN_ELO
+        val native = (stockfish || legacyStockfish) && StockfishNativeEngine.isAvailable(context)
+
         // Game-start header in the engine log: frames any fallback events
         // that follow, and makes both the band routing and the chosen
-        // backend (native binary vs WASM) visible
+        // backend visible
         val backend = when {
-            !stockfish -> "RaiEngine band"
-            native -> "Stockfish (native)"
-            else -> "Stockfish (wasm)"
+            maia -> "Maia $maiaBand"
+            stockfish || legacyStockfish ->
+                if (native) "Stockfish (native)" else "Stockfish (wasm)"
+            else -> "RaiEngine band"
         }
         EngineDiagnostics.record(context, "game start: targetElo $targetElo → $backend")
+
         return when {
-            !stockfish -> RaiEngine(targetElo)
-            native -> StockfishNativeEngine(context, targetElo, fallback = RaiEngine(targetElo))
-            else -> StockfishWasmEngine(context, targetElo, fallback = RaiEngine(targetElo))
+            maia -> MaiaEngine(context, maiaBand!!, fallback = RaiEngine(targetElo))
+            stockfish || legacyStockfish ->
+                if (native) {
+                    StockfishNativeEngine(context, targetElo, fallback = RaiEngine(targetElo))
+                } else {
+                    StockfishWasmEngine(context, targetElo, fallback = RaiEngine(targetElo))
+                }
+            else -> RaiEngine(targetElo)
         }
     }
 
     /**
-     * Full-strength analyzer for post-game analysis and coaching: Stockfish
-     * with no skill limiting, falling back to RaiEngine's fixed-depth
-     * analysis if the WASM/WebView bridge fails. Callers own the instance
-     * and must [ChessEngine.close] it when the analysis run is done.
+     * Full-strength analyzer for post-game analysis and coaching: always
+     * Stockfish (never Maia — a policy net is a move-picker, not an
+     * analyst), with RaiEngine's fixed-depth analysis as the last resort.
+     * Callers own the instance and must [ChessEngine.close] it.
      */
     fun createAnalyzer(context: Context): ChessEngine =
         if (StockfishNativeEngine.isAvailable(context)) {

--- a/app/src/main/java/com/raichess/data/engine/EngineFactory.kt
+++ b/app/src/main/java/com/raichess/data/engine/EngineFactory.kt
@@ -31,12 +31,37 @@ object EngineFactory {
      */
     const val LEGACY_STOCKFISH_MIN_ELO = 1350
 
+    /**
+     * The seam smoother: from here up to Maia's floor the opponent is
+     * maia-1100 with a lapse rate that ramps to zero at 1100, so
+     * climbing out of the RaiEngine band meets a slope, not a cliff
+     * (calibration measured RaiEngine's top far below its label, and
+     * maia-1100 beating it 12-0).
+     */
+    const val MAIA_SOFT_MIN_ELO = 950
+
+    private const val SOFT_BLUNDER_PER_ELO_POINT = 0.0012
+
     /** Pure band-selection predicate, extracted for unit testing. */
     fun usesStockfish(targetElo: Int): Boolean = targetElo >= STOCKFISH_MIN_ELO
 
+    /**
+     * Lapse probability for the eased band: 0 at Maia's floor, ~0.18 at
+     * [MAIA_SOFT_MIN_ELO], 0 everywhere Maia serves natively or not at
+     * all. Pure, tested.
+     */
+    fun maiaSoftBlunderFor(targetElo: Int): Double =
+        if (targetElo in MAIA_SOFT_MIN_ELO until MaiaEngine.MAIA_MIN_ELO) {
+            (MaiaEngine.MAIA_MIN_ELO - targetElo) * SOFT_BLUNDER_PER_ELO_POINT
+        } else {
+            0.0
+        }
+
     fun create(context: Context, targetElo: Int): ChessEngine {
         val stockfish = usesStockfish(targetElo)
+        val softBlunder = maiaSoftBlunderFor(targetElo)
         val maiaBand = MaiaEngine.netBandFor(targetElo)
+            ?: MaiaEngine.BUNDLED_BANDS.first().takeIf { softBlunder > 0 }
         val maia = maiaBand != null && MaiaEngine.isAvailable(context, maiaBand)
         // No Maia in this build: the band splits the old way (1350+
         // Stockfish, below RaiEngine)
@@ -47,6 +72,7 @@ object EngineFactory {
         // that follow, and makes both the band routing and the chosen
         // backend visible
         val backend = when {
+            maia && softBlunder > 0 -> "Maia $maiaBand (eased)"
             maia -> "Maia $maiaBand"
             stockfish || legacyStockfish ->
                 if (native) "Stockfish (native)" else "Stockfish (wasm)"
@@ -55,7 +81,12 @@ object EngineFactory {
         EngineDiagnostics.record(context, "game start: targetElo $targetElo → $backend")
 
         return when {
-            maia -> MaiaEngine(context, maiaBand!!, fallback = RaiEngine(targetElo))
+            maia -> MaiaEngine(
+                context,
+                maiaBand!!,
+                fallback = RaiEngine(targetElo),
+                blunderChance = softBlunder
+            )
             stockfish || legacyStockfish ->
                 if (native) {
                     StockfishNativeEngine(context, targetElo, fallback = RaiEngine(targetElo))

--- a/app/src/main/java/com/raichess/data/engine/MaiaEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/MaiaEngine.kt
@@ -274,7 +274,10 @@ class MaiaEngine(
         fun binaryFile(context: Context): File =
             File(context.applicationInfo.nativeLibraryDir, "liblc0.so")
 
-        private fun assetPath(band: Int) = "maia/maia-$band.pb.gz"
+        // .net, not .pb.gz: gz-suffixed assets were silently dropped from
+        // the packaged APK (see the CI weights step); the content is the
+        // gzipped net regardless, and extraction restores the real name
+        private fun assetPath(band: Int) = "maia/maia-$band.net"
 
         /** True when this APK carries both the lc0 binary and the net. */
         fun isAvailable(context: Context, band: Int): Boolean {

--- a/app/src/main/java/com/raichess/data/engine/MaiaEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/MaiaEngine.kt
@@ -1,0 +1,323 @@
+package com.raichess.data.engine
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import com.github.bhlangonijr.chesslib.Board
+import com.github.bhlangonijr.chesslib.move.Move
+import com.raichess.data.diagnostics.EngineDiagnostics
+import com.raichess.domain.model.PositionAnalysis
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.File
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * Human-like opponent: a Maia neural net (CSSLab's per-rating predictors
+ * of real human moves) served by a native lc0 binary, probed the way Maia
+ * is designed to be used — `go nodes 1`, one evaluation, the move straight
+ * from the policy head. No search means no engine-shaped play: it makes
+ * the mistakes a human at its rating makes. Calibration (CI, vs Stockfish
+ * anchors and RaiEngine) showed maia-1100 crushing our synthetic "1100"
+ * 12-0 while measuring near its label — this is the band's real opponent.
+ *
+ * Process plumbing mirrors [StockfishNativeEngine] exactly (same
+ * executable-in-jniLibs trick, same generation-scoped reader, same
+ * released/FAILED teardown split, same RaiEngine fallback contract). The
+ * weights ship as an asset and are copied to filesDir on first use —
+ * lc0 needs a real file path.
+ *
+ * Never used as an analyzer: hints and post-game analysis stay
+ * Stockfish-quality (see EngineFactory.createAnalyzer); [analyze] simply
+ * delegates to the fallback as a safety net.
+ */
+class MaiaEngine(
+    context: Context,
+    /** Net band (1100..1500 in 100s) — see [netBandFor]. */
+    private val band: Int,
+    private val fallback: ChessEngine
+) : ChessEngine {
+
+    private val appContext = context.applicationContext
+    private val output = LinkedBlockingQueue<String>()
+
+    @Volatile private var process: Process? = null
+    @Volatile private var writer: BufferedWriter? = null
+    @Volatile private var state = State.UNINITIALIZED
+    // Set once, by close() ONLY — permanent teardown. Failed inits stay
+    // retryable (same released/FAILED split as the other native engine).
+    @Volatile private var released = false
+    @Volatile private var everFellBack = false
+    @Volatile private var fallbackActive = false
+    private var initAttempts = 0
+    @Volatile private var attemptGeneration = 0
+
+    private enum class State { UNINITIALIZED, READY, FAILED }
+
+    override val activeEngineLabel: String
+        get() = when {
+            state == State.READY && everFellBack -> "Maia $band (recovered)"
+            state == State.READY -> "Maia $band"
+            everFellBack || state == State.FAILED -> "RaiEngine (fallback)"
+            else -> "Maia $band"
+        }
+
+    override fun warmUp() {
+        try {
+            ensureReady()
+        } catch (e: Exception) {
+            Log.w(TAG, "warmUp failed", e)
+        }
+    }
+
+    override fun selectMove(board: Board): Move? {
+        return try {
+            if (!ensureReady()) {
+                if (released) return null
+                return fallbackMove(board, "maia unavailable (init failed)")
+            }
+            if (released) return null
+
+            output.clear()
+            send("position fen ${board.fen}")
+            // nodes=1: no search, pure policy — the human-likeness contract
+            send("go nodes 1")
+
+            val best = awaitToken(BESTMOVE_TIMEOUT_MS) { it.startsWith("bestmove") }
+            if (best == null) {
+                if (released) return null
+                return fallbackMove(board, "no bestmove within ${BESTMOVE_TIMEOUT_MS}ms")
+            }
+            StockfishWasmEngine.parseUciBestMove(board, best)
+                ?: fallbackMove(board, "unparseable bestmove: $best")
+        } catch (e: Exception) {
+            Log.w(TAG, "selectMove failed; using RaiEngine fallback", e)
+            fallbackMove(board, "selectMove threw: ${e.javaClass.simpleName}")
+        }
+    }
+
+    /** Maia is a move-picker, not an analyst — see class doc. */
+    override fun analyze(board: Board, moveTimeMs: Long): PositionAnalysis? =
+        fallback.analyze(board, moveTimeMs)
+
+    private fun fallbackMove(board: Board, cause: String): Move? {
+        if (!fallbackActive) {
+            EngineDiagnostics.record(appContext, "moves now served by RaiEngine: $cause")
+            fallbackActive = true
+        }
+        everFellBack = true
+        return fallback.selectMove(board)
+    }
+
+    @Synchronized
+    private fun ensureReady(): Boolean {
+        if (released) return false
+        when (state) {
+            State.READY -> return true
+            State.FAILED -> {
+                if (initAttempts >= MAX_INIT_ATTEMPTS) return false
+                state = State.UNINITIALIZED
+            }
+            State.UNINITIALIZED -> Unit
+        }
+        initAttempts++
+        val initStartedAt = SystemClock.elapsedRealtime()
+
+        output.clear()
+        attemptGeneration++
+        val generation = attemptGeneration
+
+        val binary = binaryFile(appContext)
+        if (!binary.exists()) return fail("lc0 binary missing at ${binary.name}")
+        val weights = try {
+            ensureWeightsExtracted(appContext, band)
+        } catch (e: Exception) {
+            Log.w(TAG, "weights extraction failed", e)
+            return fail("weights extraction threw: ${e.javaClass.simpleName}")
+        } ?: return fail("weights asset missing for maia-$band")
+
+        try {
+            val proc = ProcessBuilder(binary.absolutePath)
+                .redirectErrorStream(true)
+                .start()
+            process = proc
+            writer = BufferedWriter(OutputStreamWriter(proc.outputStream))
+            startReader(proc, generation)
+        } catch (e: Exception) {
+            Log.w(TAG, "process start failed", e)
+            return fail("process start threw: ${e.javaClass.simpleName}")
+        }
+
+        send("uci")
+        if (awaitToken(HANDSHAKE_TIMEOUT_MS) { it == "uciok" } == null) {
+            return fail("no uciok within ${HANDSHAKE_TIMEOUT_MS}ms")
+        }
+        send("setoption name WeightsFile value ${weights.absolutePath}")
+        send("setoption name Threads value 1")
+        // The isready after WeightsFile is where the net actually loads —
+        // budget it like a model load, not a round-trip
+        send("isready")
+        if (awaitToken(WEIGHTS_READY_TIMEOUT_MS) { it == "readyok" } == null) {
+            return fail("net not loaded within ${WEIGHTS_READY_TIMEOUT_MS}ms")
+        }
+
+        state = State.READY
+        fallbackActive = false
+        val elapsed = SystemClock.elapsedRealtime() - initStartedAt
+        EngineDiagnostics.record(
+            appContext,
+            if (initAttempts > 1 || everFellBack) {
+                "maia-$band recovered (attempt $initAttempts, ${elapsed}ms)"
+            } else {
+                "maia-$band ready (${elapsed}ms)"
+            }
+        )
+        return true
+    }
+
+    private fun startReader(proc: Process, generation: Int) {
+        val thread = Thread {
+            try {
+                BufferedReader(InputStreamReader(proc.inputStream)).use { reader ->
+                    while (true) {
+                        val line = reader.readLine() ?: break
+                        if (generation != attemptGeneration) break
+                        output.offer(line.trim())
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "reader thread ended", e)
+            }
+            if (generation == attemptGeneration && !released) {
+                output.offer(ERROR_SENTINEL)
+            }
+        }
+        thread.isDaemon = true
+        thread.name = "maia-lc0-reader"
+        thread.start()
+    }
+
+    /** Must only be called from inside [ensureReady]'s lock. */
+    private fun fail(reason: String): Boolean {
+        Log.w(TAG, "maia unavailable ($reason); using RaiEngine fallback")
+        EngineDiagnostics.record(
+            appContext,
+            "maia-$band init failed (attempt $initAttempts/$MAX_INIT_ATTEMPTS): $reason"
+        )
+        state = State.FAILED
+        attemptGeneration++
+        destroyProcess()
+        return false
+    }
+
+    private fun destroyProcess() {
+        val proc = process ?: return
+        process = null
+        writer = null
+        try {
+            proc.destroy()
+        } catch (e: Exception) {
+            Log.w(TAG, "process teardown failed", e)
+        }
+    }
+
+    override fun close() {
+        released = true
+        output.offer(ERROR_SENTINEL)
+        destroyProcess()
+    }
+
+    private fun send(cmd: String) {
+        val w = writer ?: return
+        w.write(cmd)
+        w.newLine()
+        w.flush()
+    }
+
+    private fun awaitToken(timeoutMs: Long, match: (String) -> Boolean): String? {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (true) {
+            if (released) return null
+            val remaining = deadline - SystemClock.elapsedRealtime()
+            if (remaining <= 0) return null
+            val slice = remaining.coerceAtMost(POLL_SLICE_MS)
+            val line = output.poll(slice, TimeUnit.MILLISECONDS) ?: continue
+            if (line == ERROR_SENTINEL) return null
+            if (match(line)) return line
+        }
+    }
+
+    companion object {
+        private const val TAG = "MaiaEngine"
+
+        /** Nets bundled as assets (see the CI weights step). */
+        val BUNDLED_BANDS = intArrayOf(1100, 1200, 1300, 1400, 1500)
+
+        /**
+         * The nearest bundled net for a target ELO, or null when the ELO is
+         * outside Maia's serving range (below, RaiEngine's weakness is the
+         * point; above, Stockfish's skill levels take over). Pure, tested.
+         */
+        fun netBandFor(targetElo: Int): Int? {
+            if (targetElo < MAIA_MIN_ELO || targetElo >= MAIA_MAX_ELO_EXCLUSIVE) return null
+            return (((targetElo + 50) / 100) * 100)
+                .coerceIn(BUNDLED_BANDS.first(), BUNDLED_BANDS.last())
+        }
+
+        const val MAIA_MIN_ELO = 1100
+        const val MAIA_MAX_ELO_EXCLUSIVE = 1600
+
+        /** The lc0 executable the CI step packages into jniLibs. */
+        fun binaryFile(context: Context): File =
+            File(context.applicationInfo.nativeLibraryDir, "liblc0.so")
+
+        private fun assetPath(band: Int) = "maia/maia-$band.pb.gz"
+
+        /** True when this APK carries both the lc0 binary and the net. */
+        fun isAvailable(context: Context, band: Int): Boolean {
+            if (!binaryFile(context).exists()) return false
+            return try {
+                context.assets.open(assetPath(band)).use { }
+                true
+            } catch (e: Exception) {
+                false
+            }
+        }
+
+        /**
+         * Copy the net from assets to a real file (lc0 wants a path).
+         * Idempotent; returns null when the asset doesn't exist. Writes
+         * via a temp file so a killed copy can't leave a truncated net
+         * behind for every later game.
+         */
+        fun ensureWeightsExtracted(context: Context, band: Int): File? {
+            val dir = File(context.filesDir, "maia").apply { mkdirs() }
+            val target = File(dir, "maia-$band.pb.gz")
+            if (target.exists()) return target
+            return try {
+                val tmp = File(dir, "maia-$band.pb.gz.tmp")
+                context.assets.open(assetPath(band)).use { input ->
+                    tmp.outputStream().use { output -> input.copyTo(output) }
+                }
+                if (tmp.renameTo(target)) target else null
+            } catch (e: Exception) {
+                Log.w(TAG, "no bundled weights for maia-$band", e)
+                null
+            }
+        }
+
+        private const val ERROR_SENTINEL = "__error__"
+        private const val HANDSHAKE_TIMEOUT_MS = 5000L
+        // The net load lands on the isready after WeightsFile: a ~4MB
+        // model parse on a low-end phone deserves patience
+        private const val WEIGHTS_READY_TIMEOUT_MS = 20_000L
+        // nodes=1 is a single forward pass (~ms) but the FIRST eval may
+        // initialize the backend; generous grace costs nothing when fast
+        private const val BESTMOVE_TIMEOUT_MS = 10_000L
+        private const val POLL_SLICE_MS = 200L
+        private const val MAX_INIT_ATTEMPTS = 2
+    }
+}

--- a/app/src/main/java/com/raichess/data/engine/MaiaEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/MaiaEngine.kt
@@ -5,6 +5,7 @@ import android.os.SystemClock
 import android.util.Log
 import com.github.bhlangonijr.chesslib.Board
 import com.github.bhlangonijr.chesslib.move.Move
+import com.github.bhlangonijr.chesslib.move.MoveGenerator
 import com.raichess.data.diagnostics.EngineDiagnostics
 import com.raichess.domain.model.PositionAnalysis
 import java.io.BufferedReader
@@ -14,6 +15,7 @@ import java.io.InputStreamReader
 import java.io.OutputStreamWriter
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 
 /**
  * Human-like opponent: a Maia neural net (CSSLab's per-rating predictors
@@ -38,7 +40,14 @@ class MaiaEngine(
     context: Context,
     /** Net band (1100..1500 in 100s) — see [netBandFor]. */
     private val band: Int,
-    private val fallback: ChessEngine
+    private val fallback: ChessEngine,
+    /**
+     * Probability of a random legal "lapse" move instead of the net's
+     * choice — the easing that extends maia-1100 below its floor (see
+     * EngineFactory.maiaSoftBlunderFor). 0 = the pure net.
+     */
+    private val blunderChance: Double = 0.0,
+    private val random: Random = Random.Default
 ) : ChessEngine {
 
     private val appContext = context.applicationContext
@@ -57,12 +66,14 @@ class MaiaEngine(
 
     private enum class State { UNINITIALIZED, READY, FAILED }
 
+    private val maiaLabel = if (blunderChance > 0) "Maia $band (eased)" else "Maia $band"
+
     override val activeEngineLabel: String
         get() = when {
-            state == State.READY && everFellBack -> "Maia $band (recovered)"
-            state == State.READY -> "Maia $band"
+            state == State.READY && everFellBack -> "$maiaLabel (recovered)"
+            state == State.READY -> maiaLabel
             everFellBack || state == State.FAILED -> "RaiEngine (fallback)"
-            else -> "Maia $band"
+            else -> maiaLabel
         }
 
     override fun warmUp() {
@@ -75,6 +86,13 @@ class MaiaEngine(
 
     override fun selectMove(board: Board): Move? {
         return try {
+            // The easing lapse rolls before the net is consulted: a
+            // random legal move, exactly RaiEngine's weakness mechanism,
+            // so sub-floor settings err more without erring differently
+            if (blunderChance > 0 && random.nextDouble() < blunderChance) {
+                val legal = MoveGenerator.generateLegalMoves(board)
+                if (legal.isNotEmpty()) return legal[random.nextInt(legal.size)]
+            }
             if (!ensureReady()) {
                 if (released) return null
                 return fallbackMove(board, "maia unavailable (init failed)")

--- a/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/RaiEngine.kt
@@ -40,36 +40,39 @@ class RaiEngine(
 
     override val activeEngineLabel: String get() = "RaiEngine"
 
-    // Curve recalibrated on field feedback: the original mapping made the
-    // upper bands far weaker than their labels (an "1100" playing a purely
-    // random move every fifth turn on a 2-ply search was crushed by a
-    // ~600-rated player). Labels remain heuristic, but the mid band now
-    // searches deeper, blunders far less, and picks closer to the best.
+    // Curve compressed after the Maia integration: RaiEngine now serves
+    // only 400-949 as an opponent (the eased Maia band takes over from
+    // 950 — see EngineFactory), and engine-vs-engine calibration measured
+    // the old curve's whole top far below its labels. The dial therefore
+    // climbs to RaiEngine's honest maximum *within* its serving range, so
+    // the handoff to eased maia-1100 is a slope, not a cliff. Higher ELOs
+    // remain defined because RaiEngine is every engine's fallback.
 
     /** Full-move search depth in plies. */
     val searchDepth: Int = when {
-        elo < 800 -> 1
-        elo < 1100 -> 2
-        elo < 1800 -> 3
+        elo < 550 -> 1
+        elo < 700 -> 2
+        elo < 1400 -> 3
         else -> 4
     }
 
     /** Probability of playing a completely random legal move. */
     val blunderChance: Double = when {
-        elo < 500 -> 0.50   // near-random beginner bot
-        elo < 700 -> 0.30
-        elo < 900 -> 0.18
-        elo < 1100 -> 0.10
-        elo < 1300 -> 0.05
-        elo < 1600 -> 0.02
+        elo < 450 -> 0.50   // near-random beginner bot
+        elo < 550 -> 0.35
+        elo < 650 -> 0.22
+        elo < 750 -> 0.14
+        elo < 850 -> 0.08
+        elo < 950 -> 0.04
+        elo < 1300 -> 0.02
         else -> 0.0
     }
 
     /** Moves within this many centipawns of the best are candidates at lower ELOs. */
     private val candidateWindow: Int = when {
-        elo < 700 -> 200
-        elo < 1000 -> 120
-        elo < 1400 -> 60
+        elo < 500 -> 200
+        elo < 650 -> 120
+        elo < 850 -> 60
         elo < 2000 -> 25
         else -> 0
     }

--- a/app/src/main/java/com/raichess/data/engine/StockfishNativeEngine.kt
+++ b/app/src/main/java/com/raichess/data/engine/StockfishNativeEngine.kt
@@ -136,6 +136,57 @@ class StockfishNativeEngine(
         }
     }
 
+    /**
+     * MultiPV analysis for drill-alternative mining. Same single-caller
+     * contract; MultiPV is restored to 1 afterwards so ordinary analysis
+     * and play are unaffected. Falls back to the single-line default on
+     * any failure — alternatives are an enhancement, never a requirement.
+     */
+    override fun analyzeTop(board: Board, moveTimeMs: Long, multiPv: Int): List<PositionAnalysis> {
+        if (multiPv <= 1) return listOfNotNull(analyze(board, moveTimeMs))
+        return try {
+            if (!ensureReady() || released) {
+                return listOfNotNull(analyze(board, moveTimeMs))
+            }
+            val liftSkillLimit = !analysisMode && config.skillLevel < MAX_SKILL_LEVEL
+            if (liftSkillLimit) send("setoption name Skill Level value $MAX_SKILL_LEVEL")
+            send("setoption name MultiPV value $multiPv")
+            try {
+                output.clear()
+                send("position fen ${board.fen}")
+                send("go movetime $moveTimeMs")
+                // Deepest exact-score info per PV index wins, same rule as
+                // the single-line path
+                val latest = HashMap<Int, UciInfoParser.UciInfo>()
+                val best = awaitToken(moveTimeMs + BESTMOVE_GRACE_MS) { line ->
+                    UciInfoParser.parse(line)?.let { info ->
+                        if (!info.isBound && info.multipv >= 1) latest[info.multipv] = info
+                    }
+                    line.startsWith("bestmove")
+                }
+                if (best == null || latest.isEmpty()) {
+                    return listOfNotNull(analyze(board, moveTimeMs))
+                }
+                latest.entries.sortedBy { it.key }.mapNotNull { (_, info) ->
+                    val lan = info.pv.firstOrNull()?.lowercase() ?: return@mapNotNull null
+                    PositionAnalysis(
+                        scoreCp = info.scoreCp,
+                        mateIn = info.scoreMate,
+                        bestMoveLan = lan,
+                        pv = info.pv.map { it.lowercase() },
+                        depth = info.depth
+                    )
+                }
+            } finally {
+                send("setoption name MultiPV value 1")
+                if (liftSkillLimit) config.getUciCommands().forEach { send(it) }
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "analyzeTop failed; single-line fallback", e)
+            listOfNotNull(analyze(board, moveTimeMs))
+        }
+    }
+
     private fun analyzeAtCurrentStrength(board: Board, moveTimeMs: Long): PositionAnalysis? {
         output.clear()
         // No ucinewgame between analyses: a warm transposition table is

--- a/app/src/main/java/com/raichess/data/repository/GameRepository.kt
+++ b/app/src/main/java/com/raichess/data/repository/GameRepository.kt
@@ -59,24 +59,37 @@ class GameRepository(context: Context) {
 
     /**
      * The player's drillable analyzed mistakes (stored best move = answer
-     * key), newest games first, mapped for the practice queue. Shallow
-     * fallback analyses (RaiEngine, depth 3) are excluded — their "best"
-     * moves aren't trustworthy enough to demand the player reproduce
-     * them; those games regain their drills once re-analyzed by a real
-     * engine (the analyzer-version requeue does this automatically).
+     * key), newest games first, mapped for the practice queue. Two
+     * quality gates keep drills puzzle-like:
+     * - Shallow fallback analyses (RaiEngine, depth 3) are excluded —
+     *   their "best" moves aren't trustworthy answer keys. Those games
+     *   regain drills once the version requeue re-analyzes them.
+     * - Open-ended positions are excluded: a drill needs either a
+     *   substantive tagged pattern (hanging piece, missed mate, ...) or
+     *   a blunder-sized loss. A moderate positional drift in the opening
+     *   has several fine moves and no single lesson — it still feeds the
+     *   weakness profile and the review, just not a find-the-move drill.
      */
     suspend fun mistakeDrills(limit: Int = 100): List<DrillSelector.MistakeDrill> =
         dao.mistakeDrillRows(
             MoveClassifier.MISTAKE_THRESHOLD_CP,
             GameAnalyzer.MIN_TRUSTED_DEPTH,
             limit
-        ).map { row ->
+        ).filter { row ->
+            val themes = ThemeTag.fromCsv(row.themes)
+            themes.any { !it.isPhase } ||
+                row.centipawnLoss >= MoveClassifier.BLUNDER_THRESHOLD_CP
+        }.map { row ->
             DrillSelector.MistakeDrill(
                 id = "mistake:${row.gameId}:${row.ply}",
                 fen = row.fen,
                 bestMoveLan = row.bestMove,
                 playedLan = row.movePlayed,
-                themes = ThemeTag.fromCsv(row.themes)
+                themes = ThemeTag.fromCsv(row.themes),
+                acceptableLans = row.acceptableMoves
+                    .split(' ')
+                    .filter { it.isNotBlank() }
+                    .toSet()
             )
         }
 
@@ -93,6 +106,7 @@ class GameRepository(context: Context) {
                 centipawnLoss = move.centipawnLoss,
                 classification = move.classification?.name,
                 themes = ThemeTag.toCsv(move.themes),
+                acceptableMoves = move.acceptableMoves.joinToString(" "),
                 analysisDepth = move.depth,
                 analyzerVersion = GameAnalyzer.VERSION
             )

--- a/app/src/main/java/com/raichess/domain/usecase/DrillSelector.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/DrillSelector.kt
@@ -46,7 +46,13 @@ object DrillSelector {
          * ordering (mistakes sort by due-ness + recency only); carried so
          * a future weakness-first mistake ordering can mirror puzzles.
          */
-        val themes: Set<ThemeTag>
+        val themes: Set<ThemeTag>,
+        /**
+         * Moves ~as good as [bestMoveLan] (MultiPV mining) — the drill
+         * accepts any of them, since open positions often have several
+         * fine moves. Empty for rows analyzed before v4.
+         */
+        val acceptableLans: Set<String> = emptySet()
     )
 
     /** Puzzles this far from the player's ELO are filtered out. */

--- a/app/src/main/java/com/raichess/domain/usecase/DrillSelector.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/DrillSelector.kt
@@ -168,10 +168,10 @@ object DrillSelector {
                     it.rating <= targetRating + LESSON_WINDOW_ABOVE
             }
             .ifEmpty { themed }
-        val selected = inWindow
+        val ranked = inWindow
             .shuffled(Random(nowMs))
             .sortedByDescending { isDue(progressById["puzzle:${it.id}"], nowMs) }
-            .take(limit)
+        val selected = ensureLineVariety(ranked.take(limit), ranked)
         val (due, notDue) = selected.partition { isDue(progressById["puzzle:${it.id}"], nowMs) }
         val puzzleQueue = (
             spaceOutThemes(due.sortedBy { it.rating }) +
@@ -220,17 +220,51 @@ object DrillSelector {
             .filter { kotlin.math.abs(it.rating - targetRating) <= RATING_WINDOW }
             .ifEmpty { puzzles }
         // Stable sorts preserve the shuffle among equal-priority puzzles
-        val selected = inWindow
+        val ranked = inWindow
             .shuffled(Random(nowMs))
             .sortedWith(
                 compareByDescending<Puzzle> { isDue(progress["puzzle:${it.id}"], nowMs) }
                     .thenByDescending { it.themes.any { t -> t in targetThemes } }
                     .thenByDescending { it.themes.any { t -> t in phaseThemes } }
             )
-            .take(limit)
+        val selected = ensureLineVariety(ranked.take(limit), ranked)
         val (due, notDue) = selected.partition { isDue(progress["puzzle:${it.id}"], nowMs) }
         return spaceOutThemes(due.sortedBy { it.rating }) +
             spaceOutThemes(notDue.sortedBy { it.rating })
+    }
+
+    /** Minimum share of a session's puzzles that should play a 2+ move line. */
+    private const val MULTI_MOVE_MIN_DIVISOR = 3
+
+    /**
+     * Guarantee line variety: single-move puzzles dominate low-rating
+     * pools (mate-in-one, hanging pieces), so a session can end up
+     * entirely one-movers (field report). Ensure at least a third of the
+     * selection plays a multi-move line when the candidate pool has any,
+     * swapping out the lowest-priority single-move picks. [ranked] is the
+     * full priority-ordered pool the selection was taken from, so the
+     * substitutes respect due-ness and weakness preference.
+     */
+    private fun ensureLineVariety(selected: List<Puzzle>, ranked: List<Puzzle>): List<Puzzle> {
+        if (selected.isEmpty()) return selected
+        val want = selected.size / MULTI_MOVE_MIN_DIVISOR
+        val have = selected.count { it.playerMoveCount >= 2 }
+        if (have >= want) return selected
+        val selectedIds = selected.mapTo(HashSet()) { it.id }
+        val extras = ranked
+            .filter { it.playerMoveCount >= 2 && it.id !in selectedIds }
+            .take(want - have)
+        if (extras.isEmpty()) return selected
+        val result = selected.toMutableList()
+        var toDrop = extras.size
+        for (i in result.indices.reversed()) {
+            if (toDrop == 0) break
+            if (result[i].playerMoveCount < 2) {
+                result.removeAt(i)
+                toDrop--
+            }
+        }
+        return result + extras
     }
 
     /**

--- a/app/src/main/java/com/raichess/domain/usecase/GameAnalyzer.kt
+++ b/app/src/main/java/com/raichess/domain/usecase/GameAnalyzer.kt
@@ -42,6 +42,13 @@ class GameAnalyzer(
         val classification: MoveClassification?,
         /** Mistake themes (player moves at mistake-or-worse loss only). */
         val themes: Set<ThemeTag> = emptySet(),
+        /**
+         * Moves ~as good as [bestMoveLan] (graded player mistakes only,
+         * MultiPV mining): open positions often have several fine moves,
+         * and a drill demanding the engine's exact pick reads as
+         * arbitrary. Empty when the engine can't do MultiPV.
+         */
+        val acceptableMoves: List<String> = emptyList(),
         val depth: Int
     )
 
@@ -111,6 +118,12 @@ class GameAnalyzer(
                 emptySet()
             }
 
+            val classification = if (isPlayerMove) {
+                MoveClassifier.classify(evalBeforeStm, -evalAfterNextStm, playedBest)
+            } else {
+                null
+            }
+
             MoveReport(
                 ply = i,
                 fen = step.fen,
@@ -120,12 +133,13 @@ class GameAnalyzer(
                 evaluationCp = if (step.whiteToMove) evalBeforeStm else -evalBeforeStm,
                 bestMoveLan = step.analysis.bestMoveLan,
                 centipawnLoss = if (isPlayerMove) loss else null,
-                classification = if (isPlayerMove) {
-                    MoveClassifier.classify(evalBeforeStm, -evalAfterNextStm, playedBest)
-                } else {
-                    null
-                },
+                classification = classification,
                 themes = themes,
+                acceptableMoves = if (classification != null && classification in GRADED_DOWN) {
+                    acceptableAlternatives(step.fen)
+                } else {
+                    emptyList()
+                },
                 depth = step.analysis.depth
             )
         }
@@ -141,6 +155,32 @@ class GameAnalyzer(
         )
     }
 
+    /**
+     * MultiPV mining for a graded mistake's position: every alternative
+     * whose eval sits within the GOOD band of the top line is an
+     * acceptable drill answer. All evals come from the same search, same
+     * side-to-move perspective, so they compare directly. Single-line
+     * engines return no alternatives — an enhancement, not a requirement.
+     */
+    private fun acceptableAlternatives(fen: String): List<String> {
+        val board = Board().apply { loadFromFen(fen) }
+        val lines = engine.analyzeTop(board, ALTERNATIVES_MOVE_TIME_MS, ALTERNATIVES_MULTIPV)
+        if (lines.size < 2) return emptyList()
+        val bestCp = lines.first().effectiveCp()
+        return lines.drop(1)
+            .filter { alt ->
+                MoveClassifier.classify(
+                    evalBeforeCp = bestCp,
+                    evalAfterCp = alt.effectiveCp(),
+                    playedEngineBest = false
+                ) == MoveClassification.GOOD
+            }
+            .mapNotNull { it.bestMoveLan?.lowercase() }
+            // Re-validated against the real legal moves, same rule as
+            // every other engine-supplied move
+            .filter { lanToLegalMove(board, it) != null }
+    }
+
     companion object {
         /**
          * Bump when the analysis semantics change (thresholds, eval
@@ -148,8 +188,20 @@ class GameAnalyzer(
          * v2: theme tagging (Phase B).
          * v3: hybrid cp + win-probability-drop classification — stored
          * grades change, so history re-analyzes to match.
+         * v4: acceptable-alternative mining (MultiPV) for graded mistakes.
          */
-        const val VERSION = 3
+        const val VERSION = 4
+
+        /** Deeper than the per-ply sweep: only graded mistakes pay this. */
+        const val ALTERNATIVES_MOVE_TIME_MS = 400L
+        const val ALTERNATIVES_MULTIPV = 4
+
+        /** Classifications whose positions get alternative mining. */
+        private val GRADED_DOWN = setOf(
+            MoveClassification.INACCURACY,
+            MoveClassification.MISTAKE,
+            MoveClassification.BLUNDER
+        )
 
         /** Per-position budget: deep enough to grade honestly, ~15s for a 60-ply game. */
         const val DEFAULT_MOVE_TIME_MS = 250L

--- a/app/src/main/java/com/raichess/ui/practice/PracticeViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/practice/PracticeViewModel.kt
@@ -368,15 +368,27 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
 
     private fun handleMistakeMove(mistake: DrillSelector.MistakeDrill, move: Move) {
         val played = move.toString().lowercase()
-        if (played == mistake.bestMoveLan.lowercase()) {
-            board.doMove(move)
-            finishDrill(solved = true, revealLan = null)
-        } else {
-            finishDrill(solved = false, revealLan = mistake.bestMoveLan)
+        when {
+            played == mistake.bestMoveLan.lowercase() -> {
+                board.doMove(move)
+                finishDrill(solved = true, revealLan = null)
+            }
+            // Open positions often have several fine moves; any stored
+            // near-best alternative solves the drill (analyzer v4 mining)
+            played in mistake.acceptableLans -> {
+                board.doMove(move)
+                finishDrill(
+                    solved = true,
+                    revealLan = null,
+                    solvedNote = "Solved! The engine liked " +
+                        "${LanFormat.arrow(mistake.bestMoveLan)} — yours is just as good."
+                )
+            }
+            else -> finishDrill(solved = false, revealLan = mistake.bestMoveLan)
         }
     }
 
-    private fun finishDrill(solved: Boolean, revealLan: String?) {
+    private fun finishDrill(solved: Boolean, revealLan: String?, solvedNote: String? = null) {
         val state = _uiState.value
         val drillId = activePuzzle?.let { "puzzle:${it.puzzle.id}" }
             ?: activeMistake?.id ?: return
@@ -435,6 +447,7 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
             phase = if (solved) DrillPhase.SOLVED else DrillPhase.FAILED,
             prompt = when {
                 lessonDoneTitle != null -> "Tap Next for your next lesson."
+                solved && solvedNote != null -> solvedNote
                 solved -> if (streak >= 3) "Solved! $streak in a row!" else "Solved!"
                 else -> failPrompt(revealLan)
             },

--- a/app/src/main/java/com/raichess/ui/practice/PracticeViewModel.kt
+++ b/app/src/main/java/com/raichess/ui/practice/PracticeViewModel.kt
@@ -260,7 +260,11 @@ class PracticeViewModel(application: Application) : AndroidViewModel(application
                 playerIsWhite = running.solverSide == Side.WHITE,
                 phase = DrillPhase.SOLVING,
                 prompt = promptFor(running.solverSide),
-                sourceLabel = "Puzzle · ${puzzle.rating}",
+                sourceLabel = if (puzzle.playerMoveCount >= 2) {
+                    "Puzzle · ${puzzle.rating} · ${puzzle.playerMoveCount}-move line"
+                } else {
+                    "Puzzle · ${puzzle.rating}"
+                },
                 selectedSquare = null,
                 legalTargets = emptySet(),
                 revealHighlights = emptySet()

--- a/app/src/test/java/com/raichess/calibration/MaiaCalibrationTest.kt
+++ b/app/src/test/java/com/raichess/calibration/MaiaCalibrationTest.kt
@@ -3,6 +3,7 @@ package com.raichess.calibration
 import com.github.bhlangonijr.chesslib.Board
 import com.github.bhlangonijr.chesslib.Side
 import com.github.bhlangonijr.chesslib.move.MoveGenerator
+import com.raichess.data.engine.EngineFactory
 import com.raichess.data.engine.RaiEngine
 import java.io.File
 import org.junit.Assume.assumeTrue
@@ -125,6 +126,98 @@ class MaiaCalibrationTest {
         report.appendLine("Anchors floor at Stockfish's UCI_Elo minimum (1320).")
         println(report)
         assert(totalGames > 0) { "no games played — are the weights present?" }
+    }
+
+    /**
+     * Measures the RaiEngine → Maia seam: the app serves 950-1099 as
+     * maia-1100 with a lapse rate ramping to zero (the "eased" band, see
+     * EngineFactory.maiaSoftBlunderFor). Two questions per setting: how
+     * strong is it against a fixed anchor, and does it sit ABOVE the top
+     * of the compressed RaiEngine dial — i.e. is the seam monotonic?
+     */
+    @Test
+    fun `measure the eased seam below maia's floor`() {
+        assumeTrue(
+            "maia calibration is opt-in: run with -Draichess.calibrate.maia=true",
+            System.getProperty("raichess.calibrate.maia") == "true"
+        )
+        val lc0Path = System.getProperty("lc0.path") ?: "lc0"
+        val weightsDir = File(System.getProperty("maia.weights.dir") ?: ".")
+        val stockfishPath = System.getProperty("stockfish.path") ?: "stockfish"
+        val gamesPerPairing =
+            (System.getProperty("raichess.calibrate.games") ?: "$DEFAULT_GAMES").toInt()
+        val weights = File(weightsDir, "maia-1100.pb.gz")
+        assumeTrue("maia-1100 weights present", weights.isFile)
+
+        val report = StringBuilder()
+        report.appendLine("Eased-seam calibration (maia-1100 + lapse rate)")
+        report.appendLine("setting     | opponent        | games | score")
+        report.appendLine("------------+-----------------+-------+------")
+
+        UciProcessClient(listOf(lc0Path, "--weights=${weights.absolutePath}")).use { maia ->
+            maia.start()
+            for (elo in intArrayOf(950, 1050)) {
+                val eps = EngineFactory.maiaSoftBlunderFor(elo)
+                // The same lapse roll the app applies (MaiaEngine)
+                fun easedMove(fen: String, rnd: Random): String? {
+                    if (rnd.nextDouble() < eps) {
+                        val board = Board().apply { loadFromFen(fen) }
+                        val legal = MoveGenerator.generateLegalMoves(board)
+                        if (legal.isNotEmpty()) {
+                            return legal[rnd.nextInt(legal.size)].toString().lowercase()
+                        }
+                    }
+                    return maia.bestMoveNodes(fen, 1)
+                }
+
+                // vs the top of the compressed RaiEngine dial: monotonic
+                // seam means this stays above 0.5
+                var raiScore = 0.0
+                repeat(gamesPerPairing) { game ->
+                    val rnd = Random(elo * 31 + game)
+                    val rai = RaiEngine(targetElo = 900, random = Random(elo * 977 + game))
+                    raiScore += playGame(
+                        white = { fen ->
+                            if (game % 2 == 0) easedMove(fen, rnd) else raiMove(rai, fen)
+                        },
+                        black = { fen ->
+                            if (game % 2 == 0) raiMove(rai, fen) else easedMove(fen, rnd)
+                        },
+                        scoredSideIsWhite = game % 2 == 0
+                    )
+                }
+                report.appendLine(
+                    "eased %4d | RaiEngine   900 | %5d | %.3f".format(
+                        elo, gamesPerPairing, raiScore / gamesPerPairing
+                    )
+                )
+
+                UciProcessClient(stockfishPath).use { stockfish ->
+                    stockfish.startLimitedTo(1320)
+                    var sfScore = 0.0
+                    repeat(gamesPerPairing) { game ->
+                        val rnd = Random(elo * 53 + game)
+                        sfScore += playGame(
+                            white = { fen ->
+                                if (game % 2 == 0) easedMove(fen, rnd)
+                                else stockfish.bestMove(fen, SF_MOVE_TIME_MS)
+                            },
+                            black = { fen ->
+                                if (game % 2 == 0) stockfish.bestMove(fen, SF_MOVE_TIME_MS)
+                                else easedMove(fen, rnd)
+                            },
+                            scoredSideIsWhite = game % 2 == 0
+                        )
+                    }
+                    report.appendLine(
+                        "eased %4d | Stockfish  1320 | %5d | %.3f".format(
+                            elo, gamesPerPairing, sfScore / gamesPerPairing
+                        )
+                    )
+                }
+            }
+        }
+        println(report)
     }
 
     /** RaiEngine as a UCI-shaped move provider over a FEN. */

--- a/app/src/test/java/com/raichess/data/engine/EngineFactoryTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/EngineFactoryTest.kt
@@ -1,6 +1,8 @@
 package com.raichess.data.engine
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -14,9 +16,39 @@ class EngineFactoryTest {
     }
 
     @Test
-    fun `raiengine is used below the min elo`() {
+    fun `stockfish is not used below the min elo`() {
         assertFalse(EngineFactory.usesStockfish(EngineFactory.STOCKFISH_MIN_ELO - 1))
         assertFalse(EngineFactory.usesStockfish(800))
         assertFalse(EngineFactory.usesStockfish(400))
+    }
+
+    @Test
+    fun `the maia band sits between raiengine and stockfish`() {
+        // Below 1100: RaiEngine territory, no net
+        assertNull(MaiaEngine.netBandFor(400))
+        assertNull(MaiaEngine.netBandFor(1099))
+        // 1100-1599: nearest bundled net in 100s
+        assertEquals(1100, MaiaEngine.netBandFor(1100))
+        assertEquals(1100, MaiaEngine.netBandFor(1149))
+        assertEquals(1200, MaiaEngine.netBandFor(1150))
+        assertEquals(1300, MaiaEngine.netBandFor(1300))
+        assertEquals(1500, MaiaEngine.netBandFor(1500))
+        // Top of the band clamps to the strongest bundled net
+        assertEquals(1500, MaiaEngine.netBandFor(1599))
+        // 1600+: Stockfish territory, no net
+        assertNull(MaiaEngine.netBandFor(1600))
+        assertNull(MaiaEngine.netBandFor(2800))
+    }
+
+    @Test
+    fun `maia and stockfish bands never overlap`() {
+        for (elo in 400..2800 step 50) {
+            val maia = MaiaEngine.netBandFor(elo) != null
+            val stockfish = EngineFactory.usesStockfish(elo)
+            assertFalse("both engines claim $elo", maia && stockfish)
+        }
+        // And together with RaiEngine below, every ELO is covered:
+        // netBandFor's range starts exactly where RaiEngine's ends
+        assertEquals(EngineFactory.STOCKFISH_MIN_ELO, MaiaEngine.MAIA_MAX_ELO_EXCLUSIVE)
     }
 }

--- a/app/src/test/java/com/raichess/data/engine/EngineFactoryTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/EngineFactoryTest.kt
@@ -41,6 +41,20 @@ class EngineFactoryTest {
     }
 
     @Test
+    fun `the eased band ramps lapses from the soft floor to zero at maia's floor`() {
+        // Outside the seam: no easing
+        assertEquals(0.0, EngineFactory.maiaSoftBlunderFor(949), 1e-9)
+        assertEquals(0.0, EngineFactory.maiaSoftBlunderFor(1100), 1e-9)
+        assertEquals(0.0, EngineFactory.maiaSoftBlunderFor(2000), 1e-9)
+        // Inside: linear ramp, ~18% at the soft floor, vanishing at 1100
+        assertEquals(0.18, EngineFactory.maiaSoftBlunderFor(950), 1e-9)
+        assertEquals(0.06, EngineFactory.maiaSoftBlunderFor(1050), 1e-9)
+        assertTrue(
+            EngineFactory.maiaSoftBlunderFor(1099) < EngineFactory.maiaSoftBlunderFor(951)
+        )
+    }
+
+    @Test
     fun `maia and stockfish bands never overlap`() {
         for (elo in 400..2800 step 50) {
             val maia = MaiaEngine.netBandFor(elo) != null

--- a/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
+++ b/app/src/test/java/com/raichess/data/engine/RaiEngineTest.kt
@@ -81,10 +81,11 @@ class RaiEngineTest {
 
     @Test
     fun `weakest settings blunder more than mid settings`() {
-        // The 400-600 beginner band is near-random by design
-        assertTrue(RaiEngine(450).blunderChance > RaiEngine(900).blunderChance)
+        // The bottom of the (post-Maia, compressed) dial is near-random
+        // by design
+        assertTrue(RaiEngine(420).blunderChance > RaiEngine(900).blunderChance)
         assertTrue(RaiEngine(650).blunderChance > RaiEngine(900).blunderChance)
-        assertTrue(RaiEngine(450).blunderChance >= 0.5)
+        assertTrue(RaiEngine(420).blunderChance >= 0.5)
     }
 
     @org.junit.Test
@@ -98,21 +99,21 @@ class RaiEngineTest {
 
     @Test
     fun `weak engine deviates from the best move on some seeds`() {
-        // Hanging queen: the objectively best move is c4xd5. An 800-ELO
-        // engine blunders 30% of the time, so across many seeds it must
+        // Hanging queen: the objectively best move is c4xd5. A 600-ELO
+        // engine blunders 22% of the time, so across many seeds it must
         // sometimes play something else.
         var deviated = false
         for (seed in 0..40) {
             val board = Board()
             board.loadFromFen("rnb1kbnr/ppp1pppp/8/3q4/2P5/8/PP1PPPPP/RNBQKBNR w KQkq - 0 3")
-            val engine = RaiEngine(targetElo = 800, random = Random(seed))
+            val engine = RaiEngine(targetElo = 600, random = Random(seed))
             val move = checkNotNull(engine.selectMove(board))
             if (move.toString() != "c4d5") {
                 deviated = true
                 break
             }
         }
-        assertTrue("an 800-ELO engine should not always find the best move", deviated)
+        assertTrue("a 600-ELO engine should not always find the best move", deviated)
     }
 
     @Test
@@ -122,7 +123,7 @@ class RaiEngineTest {
         val chosen = mutableSetOf<String>()
         for (seed in 0..20) {
             val board = Board()
-            val engine = RaiEngine(targetElo = 900, random = Random(seed))
+            val engine = RaiEngine(targetElo = 600, random = Random(seed))
             chosen.add(checkNotNull(engine.selectMove(board)).toString())
         }
         assertTrue(

--- a/app/src/test/java/com/raichess/domain/usecase/DrillSelectorTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/DrillSelectorTest.kt
@@ -16,6 +16,10 @@ class DrillSelectorTest {
     private fun puzzle(id: String, rating: Int, vararg themes: String) =
         Puzzle(id, "fen-$id", listOf("e2e4", "e7e5"), rating, themes.toSet())
 
+    /** A two-player-move line (setup + move, reply, move). */
+    private fun multiPuzzle(id: String, rating: Int, vararg themes: String) =
+        Puzzle(id, "fen-$id", listOf("e2e4", "e7e5", "g1f3", "b8c6"), rating, themes.toSet())
+
     private fun mistake(id: String) = DrillSelector.MistakeDrill(
         id = id, fen = "fen-$id", bestMoveLan = "e2e4", playedLan = "a2a3",
         themes = setOf(ThemeTag.HANGING_PIECE)
@@ -232,6 +236,71 @@ class DrillSelectorTest {
         assertEquals(queueAt(now), queueAt(now))
         // 8 equal-rating puzzles: some nearby seed must produce a new order
         assertTrue((1L..5L).any { queueAt(now + it) != queueAt(now) })
+    }
+
+    @Test
+    fun `sessions guarantee a share of multi-move lines when the pool has them`() {
+        // 6 single-movers outrank the multis in the shuffle-agnostic sense
+        // (all equal priority), so without the variety guarantee a session
+        // could easily select zero multi-move lines
+        val singles = (1..6).map { puzzle("s$it", 800, "theme$it") }
+        val multis = listOf(
+            multiPuzzle("m1", 850, "fork"),
+            multiPuzzle("m2", 860, "pin")
+        )
+        val queue = DrillSelector.buildQueue(
+            source = DrillSelector.Source.PUZZLES,
+            mistakes = emptyList(),
+            puzzles = singles + multis,
+            progressById = emptyMap(),
+            targetRating = 800,
+            weaknesses = emptyList(),
+            nowMs = now,
+            limit = 6
+        ).map { it.puzzle!! }
+        assertEquals(6, queue.size)
+        // limit/3 = 2: both multi-move lines must make the session
+        assertEquals(2, queue.count { it.playerMoveCount >= 2 })
+    }
+
+    @Test
+    fun `an all-single-move pool is served unchanged`() {
+        val queue = DrillSelector.buildQueue(
+            source = DrillSelector.Source.PUZZLES,
+            mistakes = emptyList(),
+            puzzles = (1..6).map { puzzle("s$it", 800, "theme$it") },
+            progressById = emptyMap(),
+            targetRating = 800,
+            weaknesses = emptyList(),
+            nowMs = now,
+            limit = 6
+        )
+        assertEquals(6, queue.size)
+        assertTrue(queue.all { it.puzzle!!.playerMoveCount == 1 })
+    }
+
+    @Test
+    fun `lesson queues also guarantee multi-move variety`() {
+        val lesson = LessonPlanner.Lesson(
+            id = "core:tactics", title = "t", description = "",
+            themes = setOf("fork")
+        )
+        val singles = (1..6).map { puzzle("s$it", 800, "fork") }
+        val multis = listOf(
+            multiPuzzle("m1", 850, "fork"),
+            multiPuzzle("m2", 860, "fork")
+        )
+        val queue = DrillSelector.buildLessonQueue(
+            lesson = lesson,
+            mistakes = emptyList(),
+            puzzles = singles + multis,
+            progressById = emptyMap(),
+            targetRating = 800,
+            nowMs = now,
+            limit = 6
+        ).mapNotNull { it.puzzle }
+        assertEquals(6, queue.size)
+        assertEquals(2, queue.count { it.playerMoveCount >= 2 })
     }
 
     @Test

--- a/app/src/test/java/com/raichess/domain/usecase/GameAnalyzerTest.kt
+++ b/app/src/test/java/com/raichess/domain/usecase/GameAnalyzerTest.kt
@@ -17,7 +17,7 @@ import org.junit.Test
 class GameAnalyzerTest {
 
     /** Returns the queued analyses in order; fails the test if over-consumed. */
-    private class ScriptedEngine(analyses: List<PositionAnalysis?>) : ChessEngine {
+    private open class ScriptedEngine(analyses: List<PositionAnalysis?>) : ChessEngine {
         private val queue = analyses.toMutableList()
         var calls = 0
             private set
@@ -29,6 +29,14 @@ class GameAnalyzerTest {
             check(queue.isNotEmpty()) { "engine asked for more analyses than scripted" }
             return queue.removeAt(0)
         }
+
+        // No MultiPV by default: the alternative-mining pass must consume
+        // nothing from the per-ply script (mirrors single-line engines)
+        override fun analyzeTop(
+            board: Board,
+            moveTimeMs: Long,
+            multiPv: Int
+        ): List<PositionAnalysis> = emptyList()
     }
 
     private fun cp(score: Int, best: String) =
@@ -103,6 +111,40 @@ class GameAnalyzerTest {
         assertEquals(-1000, qh4.evaluationCp)
 
         assertEquals((70 + 920) / 2.0, report.acpl, 1e-9)
+    }
+
+    @Test
+    fun `graded mistakes store near-best alternatives, filtered to the GOOD band`() {
+        // Same fool's-mate script as above; the engine additionally offers
+        // MultiPV lines for the graded g4?? position (after 1.f3 e5):
+        // e2e4 sits within the GOOD band of the top line (15cp), h2h4
+        // does not (220cp / ~18 win-percent points) and must be rejected
+        val engine = object : ScriptedEngine(
+            listOf(
+                cp(20, "e2e4"),
+                cp(50, "e7e5"),
+                cp(-80, "d2d4"),
+                PositionAnalysis(scoreCp = null, mateIn = 1, bestMoveLan = "d8h4", depth = 15)
+            )
+        ) {
+            override fun analyzeTop(
+                board: Board,
+                moveTimeMs: Long,
+                multiPv: Int
+            ): List<PositionAnalysis> = listOf(
+                cp(-80, "d2d4"),
+                cp(-95, "e2e4"),
+                cp(-300, "h2h4")
+            )
+        }
+        val report = GameAnalyzer(engine)
+            .analyze(listOf("f2f3", "e7e5", "g2g4", "d8h4"), playerIsWhite = true)!!
+
+        val g4 = report.moves[2]
+        assertEquals(listOf("e2e4"), g4.acceptableMoves)
+        // Ungraded moves never mine alternatives
+        assertTrue(report.moves[0].acceptableMoves.isEmpty())
+        assertTrue(report.moves[1].acceptableMoves.isEmpty())
     }
 
     @Test

--- a/tools/lc0-android/arm64-v8a.txt
+++ b/tools/lc0-android/arm64-v8a.txt
@@ -1,0 +1,19 @@
+# Meson cross file for building lc0 against the Android NDK (arm64).
+# Binary names resolve via PATH — the CI step prepends the NDK's
+# llvm/prebuilt/linux-x86_64/bin. API 24 matches the app's minSdk.
+[binaries]
+c = 'aarch64-linux-android24-clang'
+cpp = 'aarch64-linux-android24-clang++'
+ar = 'llvm-ar'
+strip = 'llvm-strip'
+
+[host_machine]
+system = 'android'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[built-in options]
+cpp_args = ['-O3']
+# Executables must be position-independent on modern Android
+cpp_link_args = ['-static-libstdc++', '-pie']

--- a/tools/lc0-android/armeabi-v7a.txt
+++ b/tools/lc0-android/armeabi-v7a.txt
@@ -1,0 +1,19 @@
+# Meson cross file for building lc0 against the Android NDK (armv7).
+# Binary names resolve via PATH — the CI step prepends the NDK's
+# llvm/prebuilt/linux-x86_64/bin. API 24 matches the app's minSdk.
+[binaries]
+c = 'armv7a-linux-androideabi24-clang'
+cpp = 'armv7a-linux-androideabi24-clang++'
+ar = 'llvm-ar'
+strip = 'llvm-strip'
+
+[host_machine]
+system = 'android'
+cpu_family = 'arm'
+cpu = 'armv7a'
+endian = 'little'
+
+[built-in options]
+cpp_args = ['-O3', '-mfpu=neon']
+# Executables must be position-independent on modern Android
+cpp_link_args = ['-static-libstdc++', '-pie']


### PR DESCRIPTION
Four rounds on one branch, all driven by the calibration data and field feedback.

## 1. Maia human-like opponents (1100–1599)

Calibration verdict: **maia-1100 beat RaiEngine&#39;s &#34;1100&#34; 12–0** while measuring near its label. `MaiaEngine` serves CSSLab&#39;s per-rating nets via a native lc0 binary at `go nodes 1` — pure policy, no search, so it errs like a human. Plumbing mirrors `StockfishNativeEngine` (executable-in-jniLibs, generation-scoped reader, RaiEngine fallback). Five nets (1100–1500, ~17MB) ship as assets. CI cross-builds lc0 per ABI (meson cross files, Eigen CPU backend), fetches the nets, and fails the build if either is missing from the APK. Maia is never the analyzer — hints/analysis stay Stockfish.

*(CI archaeology: v0.31.2 has no `eigen` option — the CPU path is the `blas` backend falling back to header-only Eigen; and `.gz`-suffixed assets were silently dropped from the APK, so the nets ship as `.net` and extraction restores the real name.)*

## 2. The RaiEngine → Maia seam is a slope, not a cliff

- **Eased band (950–1099):** the opponent is maia-1100 with a lapse rate ramping ~18% → 0 (a random legal move — RaiEngine&#39;s exact weakness mechanism), so the same human brain spans the seam, just increasingly error-prone at lower settings. Label: &#34;Maia 1100 (eased)&#34;.
- **RaiEngine&#39;s dial compressed into its honest range (400–949):** curves climb to its real maximum where the eased band takes over, instead of wasting half the dial on labels calibration proved it can&#39;t play.
- The calibrate-maia workflow gained a **seam measurement** (eased 950/1050 vs RaiEngine&#39;s top and a Stockfish anchor) so the transition&#39;s monotonicity is a number, not a hope.

## 3. Mistake drills stop demanding the one engine move

Field report: early-game mistakes make poor puzzles — several moves are good-to-best, but the drill failed everything except the engine&#39;s pick.

- **Alternative mining (analyzer v4):** graded mistakes get a MultiPV re-analysis (4 lines, 400ms, native Stockfish — only mistakes pay it); alternatives within the GOOD band of the top line are stored (`positions.acceptableMoves`, **DB v2 with a real migration** — no data loss) and the drill accepts them: *&#34;Solved! The engine liked g1→f3 — yours is just as good.&#34;*
- **Drill gate:** a from-your-games drill now needs a substantive tagged pattern (hanging piece, missed mate, …) or a blunder-sized loss. Moderate positional drifts with several fine continuations still feed the weakness profile and review — they just stop masquerading as find-the-one-move puzzles.

`ChessEngine.analyzeTop` (default single-line) + real MultiPV in `StockfishNativeEngine` with option restoration. History re-analyzes under v4 automatically, so old games gain alternatives too.

## 4. Puzzle sessions guarantee multi-move lines

Field report: every puzzle so far was one move. The drill machinery already plays full Lichess lines (opponent replies auto-play between your moves) — the monotony was pure selection: low-rating pools are dominated by mate-in-one and hanging-piece one-movers, and the selector never asked for length variety. `DrillSelector` now guarantees **at least a third of each session plays a 2+ move line** whenever the candidate pool has any, swapping out the lowest-priority single-move picks (substitutes taken in priority order, so due-ness and weakness matching still hold). Applies to regular and lesson queues; the drill label says so up front (&#34;Puzzle · 850 · 2-move line&#34;) so a sequence is expected, not a surprise.

Tests: routing invariants incl. band-overlap sweep, eased-ramp mapping, recalibrated RaiEngine curve, MultiPV mining incl. GOOD-band filtering, line-variety guarantee (mixed pool, all-single pool, lesson queue). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6BQgEyH3h7Mk4fvSYRa4p